### PR TITLE
Makes ContentFormat modifiable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add OpenWEC node name (if configured) in JSON format output (#2)
+- Make ContentFormat configurable (#1)
 
 ## [0.1.0] - 2023-05-30
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -60,7 +60,7 @@ async fn main() {
                     .arg(
                         arg!(--"content-format" <CONTENT_FORMAT> "If set to Raw, retrieve only the \
                         EventData part of events. If set to RenderedText, retrieve the \
-                        RenderingInfo part as well. RenderingInfo increases the size of the events \
+                        RenderingInfo part as well. RenderingInfo increases the size of events \
                         but can help with analysis.")
                         .value_parser(["Raw", "RenderedText"])
                         .default_value("Raw")
@@ -165,10 +165,9 @@ async fn main() {
                     .arg(
                         arg!(--"content-format" <CONTENT_FORMAT> "If set to Raw, retrieve only the \
                         EventData part of events. If set to RenderedText, retrieve the \
-                        RenderingInfo part as well. RenderingInfo increases the size of the events \
+                        RenderingInfo part as well. RenderingInfo increases the size of events \
                         but can help with analysis.")
                         .value_parser(["Raw", "RenderedText"])
-                        .default_value("Raw")
                     )
                     .group(ArgGroup::new("subscription_status").args(["enable", "disable"]).required(false))
                 )

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -57,6 +57,14 @@ async fn main() {
                     .arg(
                         arg!(--"read-existing-events" "Subscription retrieves already existing events in addition to new ones")
                     )
+                    .arg(
+                        arg!(--"content-format" <CONTENT_FORMAT> "If set to Raw, retrieve only the \
+                        EventData part of events. If set to RenderedText, retrieve the \
+                        RenderingInfo part as well. RenderingInfo increases the size of the events \
+                        but can help with analysis.")
+                        .value_parser(["Raw", "RenderedText"])
+                        .default_value("Raw")
+                    )
                 )
                 .subcommand(
                     Command::new("edit")
@@ -153,6 +161,14 @@ async fn main() {
                     )
                     .arg(
                         arg!(--"disable" "Disable the subscription")
+                    )
+                    .arg(
+                        arg!(--"content-format" <CONTENT_FORMAT> "If set to Raw, retrieve only the \
+                        EventData part of events. If set to RenderedText, retrieve the \
+                        RenderingInfo part as well. RenderingInfo increases the size of the events \
+                        but can help with analysis.")
+                        .value_parser(["Raw", "RenderedText"])
+                        .default_value("Raw")
                     )
                     .group(ArgGroup::new("subscription_status").args(["enable", "disable"]).required(false))
                 )

--- a/cli/src/subscriptions.rs
+++ b/cli/src/subscriptions.rs
@@ -2,8 +2,8 @@ use common::{
     database::Db,
     encoding::decode_utf16le,
     subscription::{
-        FileConfiguration, KafkaConfiguration, SubscriptionData, SubscriptionMachineState,
-        SubscriptionOutput, SubscriptionOutputFormat, TcpConfiguration,
+        ContentFormat, FileConfiguration, KafkaConfiguration, SubscriptionData,
+        SubscriptionMachineState, SubscriptionOutput, SubscriptionOutputFormat, TcpConfiguration,
     },
 };
 use roxmltree::{Document, Node};
@@ -311,8 +311,14 @@ async fn edit(db: &Db, matches: &ArgMatches) -> Result<()> {
         subscription.set_enabled(false);
     }
     if let Some(content_format) = matches.get_one::<String>("content-format") {
-        debug!("Update ContentFormat from {} to {}", subscription.content_format(), content_format);
-        subscription.set_content_format(content_format.to_owned());
+        let content_format_t =
+            ContentFormat::from_str(&content_format).context("Parse content-format argument")?;
+        debug!(
+            "Update content_format from {} to {}",
+            subscription.content_format().to_string(),
+            content_format_t.to_string()
+        );
+        subscription.set_content_format(content_format_t);
     }
     info!(
         "Saving subscription {} ({})",
@@ -338,6 +344,12 @@ async fn new(db: &Db, matches: &ArgMatches) -> Result<()> {
         return Ok(());
     }
 
+    let content_format = ContentFormat::from_str(
+        matches
+            .get_one::<String>("content-format")
+            .expect("Defaulted by clap"),
+    )?;
+
     let subscription = SubscriptionData::new(
         matches.get_one::<String>("name").expect("Required by clap"),
         matches.get_one::<String>("uri").map(|e| e.as_str()),
@@ -351,7 +363,7 @@ async fn new(db: &Db, matches: &ArgMatches) -> Result<()> {
         *matches
             .get_one::<bool>("read-existing-events")
             .expect("defaulted by clap"),
-        matches.get_one::<String>("content-format").expect("Required by clap"),
+        content_format,
         None,
     );
     debug!(
@@ -470,7 +482,11 @@ fn import_windows(mut reader: BufReader<File>) -> Result<Vec<SubscriptionData>> 
             data.set_query(node.text().map(String::from).unwrap());
         } else if node.has_tag_name("ReadExistingEvents") && node.text().is_some() {
             data.set_read_existing_events(node.text().unwrap().parse()?);
+        } else if node.has_tag_name("ContentFormat") && node.text().is_some() {
+            let content_format = ContentFormat::from_str(node.text().unwrap())?;
+            data.set_content_format(content_format);
         }
+
     }
 
     Ok(vec![data])

--- a/cli/src/subscriptions.rs
+++ b/cli/src/subscriptions.rs
@@ -310,6 +310,10 @@ async fn edit(db: &Db, matches: &ArgMatches) -> Result<()> {
         debug!("Update enable from {} to true", subscription.enabled());
         subscription.set_enabled(false);
     }
+    if let Some(content_format) = matches.get_one::<String>("content-format") {
+        debug!("Update ContentFormat from {} to {}", subscription.content_format(), content_format);
+        subscription.set_content_format(content_format.to_owned());
+    }
     info!(
         "Saving subscription {} ({})",
         subscription.name(),
@@ -347,6 +351,7 @@ async fn new(db: &Db, matches: &ArgMatches) -> Result<()> {
         *matches
             .get_one::<bool>("read-existing-events")
             .expect("defaulted by clap"),
+        matches.get_one::<String>("content-format").expect("Required by clap"),
         None,
     );
     debug!(

--- a/common/src/database/mod.rs
+++ b/common/src/database/mod.rs
@@ -124,7 +124,9 @@ pub mod tests {
 
     use crate::{
         heartbeat::{HeartbeatKey, HeartbeatValue},
-        subscription::{FileConfiguration, SubscriptionOutput, SubscriptionOutputFormat},
+        subscription::{
+            ContentFormat, FileConfiguration, SubscriptionOutput, SubscriptionOutputFormat,
+        },
     };
 
     use super::{schema::Migrator, *};
@@ -161,7 +163,7 @@ pub mod tests {
             None,
             false,
             false,
-            "RenderedText",
+            ContentFormat::Raw,
             None,
         );
         db.store_subscription(subscription.clone()).await?;
@@ -172,7 +174,7 @@ pub mod tests {
         assert_eq!(toto.query(), "query",);
         assert_eq!(toto.enabled(), false);
         assert_eq!(toto.read_existing_events(), false);
-        assert_eq!(toto.content_format(), "RenderedText");
+        assert_eq!(toto.content_format(), &ContentFormat::Raw);
 
         let toto2 = db.get_subscription_by_identifier("toto").await?.unwrap();
         assert_eq!(toto, &toto2);
@@ -200,7 +202,7 @@ pub mod tests {
             None,
             true,
             true,
-            "Raw",
+            ContentFormat::RenderedText,
             Some(vec![
                 SubscriptionOutput::Files(
                     SubscriptionOutputFormat::Json,
@@ -224,7 +226,7 @@ pub mod tests {
         assert_eq!(tata.query(), "query2",);
         assert_eq!(tata.enabled(), true);
         assert_eq!(tata.read_existing_events(), true);
-        assert_eq!(tata.content_format(), "Raw");
+        assert_eq!(tata.content_format(), &ContentFormat::RenderedText);
         assert_eq!(
             tata.outputs(),
             vec![
@@ -245,7 +247,7 @@ pub mod tests {
         tata.set_name("titi".to_string());
         tata.set_max_time(25000);
         tata.set_read_existing_events(false);
-        tata.set_content_format("RenderedText".to_string());
+        tata.set_content_format(ContentFormat::Raw);
         db.store_subscription(tata.clone()).await?;
 
         ensure!(db.get_subscriptions().await?.len() == 2);
@@ -256,7 +258,7 @@ pub mod tests {
         assert_eq!(tata2.name(), "titi");
         assert_eq!(tata2.max_time(), 25000);
         assert_eq!(tata2.read_existing_events(), false);
-        assert_eq!(tata2.content_format(), "RenderedText");
+        assert_eq!(tata2.content_format(), &ContentFormat::Raw);
         assert!(tata2.version() != tata_save.version());
 
         db.delete_subscription(toto4.uuid()).await?;
@@ -279,11 +281,34 @@ pub mod tests {
     pub async fn test_bookmarks(db: Arc<dyn Database>) -> Result<()> {
         setup_db(db.clone()).await?;
         let subscription_tutu = SubscriptionData::new(
-            "tutu", None, "query", None, None, None, None, None, false, false, "Raw", None,
+            "tutu",
+            None,
+            "query",
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+            false,
+            ContentFormat::Raw,
+            None,
+
         );
         db.store_subscription(subscription_tutu.clone()).await?;
         let subscription_titi = SubscriptionData::new(
-            "titi", None, "query", None, None, None, None, None, false, false, "Raw", None,
+            "titi",
+            None,
+            "query",
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+            false,
+            ContentFormat::RenderedText,
+            None,
         );
         db.store_subscription(subscription_titi.clone()).await?;
 
@@ -489,7 +514,18 @@ pub mod tests {
         assert!(db.get_heartbeats().await?.is_empty());
 
         let subscription_tutu = SubscriptionData::new(
-            "tutu", None, "query", None, None, None, None, None, false, false, "Raw", None,
+            "tutu",
+            None,
+            "query",
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+            false,
+            ContentFormat::Raw,
+            None,
         );
 
         db.store_subscription(subscription_tutu.clone()).await?;
@@ -599,7 +635,18 @@ pub mod tests {
         setup_db(db.clone()).await?;
 
         let subscription_tutu = SubscriptionData::new(
-            "tutu", None, "query", None, None, None, None, None, false, false, "Raw", None,
+            "tutu",
+            None,
+            "query",
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+            false,
+            ContentFormat::RenderedText,
+            None,
         );
 
         db.store_subscription(subscription_tutu.clone()).await?;
@@ -732,7 +779,18 @@ pub mod tests {
         );
 
         let subscription_tutu = SubscriptionData::new(
-            "tutu", None, "query", None, None, None, None, None, false, false, "Raw", None,
+            "tutu",
+            None,
+            "query",
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+            false,
+            ContentFormat::Raw,
+            None,
         );
 
         db.store_subscription(subscription_tutu.clone()).await?;
@@ -950,7 +1008,18 @@ pub mod tests {
 
         // Create another subscription
         let subscription_tata = SubscriptionData::new(
-            "tata", None, "query", None, None, None, None, None, false, false, "Raw", None,
+            "tata",
+            None,
+            "query",
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+            false,
+            ContentFormat::Raw,
+            None,
         );
 
         db.store_subscription(subscription_tata.clone()).await?;

--- a/common/src/database/mod.rs
+++ b/common/src/database/mod.rs
@@ -161,6 +161,7 @@ pub mod tests {
             None,
             false,
             false,
+            "RenderedText",
             None,
         );
         db.store_subscription(subscription.clone()).await?;
@@ -171,6 +172,7 @@ pub mod tests {
         assert_eq!(toto.query(), "query",);
         assert_eq!(toto.enabled(), false);
         assert_eq!(toto.read_existing_events(), false);
+        assert_eq!(toto.content_format(), "RenderedText");
 
         let toto2 = db.get_subscription_by_identifier("toto").await?.unwrap();
         assert_eq!(toto, &toto2);
@@ -198,6 +200,7 @@ pub mod tests {
             None,
             true,
             true,
+            "Raw",
             Some(vec![
                 SubscriptionOutput::Files(
                     SubscriptionOutputFormat::Json,
@@ -221,6 +224,7 @@ pub mod tests {
         assert_eq!(tata.query(), "query2",);
         assert_eq!(tata.enabled(), true);
         assert_eq!(tata.read_existing_events(), true);
+        assert_eq!(tata.content_format(), "Raw");
         assert_eq!(
             tata.outputs(),
             vec![
@@ -241,6 +245,7 @@ pub mod tests {
         tata.set_name("titi".to_string());
         tata.set_max_time(25000);
         tata.set_read_existing_events(false);
+        tata.set_content_format("RenderedText".to_string());
         db.store_subscription(tata.clone()).await?;
 
         ensure!(db.get_subscriptions().await?.len() == 2);
@@ -251,6 +256,7 @@ pub mod tests {
         assert_eq!(tata2.name(), "titi");
         assert_eq!(tata2.max_time(), 25000);
         assert_eq!(tata2.read_existing_events(), false);
+        assert_eq!(tata2.content_format(), "RenderedText");
         assert!(tata2.version() != tata_save.version());
 
         db.delete_subscription(toto4.uuid()).await?;
@@ -273,11 +279,11 @@ pub mod tests {
     pub async fn test_bookmarks(db: Arc<dyn Database>) -> Result<()> {
         setup_db(db.clone()).await?;
         let subscription_tutu = SubscriptionData::new(
-            "tutu", None, "query", None, None, None, None, None, false, false, None,
+            "tutu", None, "query", None, None, None, None, None, false, false, "Raw", None,
         );
         db.store_subscription(subscription_tutu.clone()).await?;
         let subscription_titi = SubscriptionData::new(
-            "titi", None, "query", None, None, None, None, None, false, false, None,
+            "titi", None, "query", None, None, None, None, None, false, false, "Raw", None,
         );
         db.store_subscription(subscription_titi.clone()).await?;
 
@@ -483,7 +489,7 @@ pub mod tests {
         assert!(db.get_heartbeats().await?.is_empty());
 
         let subscription_tutu = SubscriptionData::new(
-            "tutu", None, "query", None, None, None, None, None, false, false, None,
+            "tutu", None, "query", None, None, None, None, None, false, false, "Raw", None,
         );
 
         db.store_subscription(subscription_tutu.clone()).await?;
@@ -593,7 +599,7 @@ pub mod tests {
         setup_db(db.clone()).await?;
 
         let subscription_tutu = SubscriptionData::new(
-            "tutu", None, "query", None, None, None, None, None, false, false, None,
+            "tutu", None, "query", None, None, None, None, None, false, false, "Raw", None,
         );
 
         db.store_subscription(subscription_tutu.clone()).await?;
@@ -726,7 +732,7 @@ pub mod tests {
         );
 
         let subscription_tutu = SubscriptionData::new(
-            "tutu", None, "query", None, None, None, None, None, false, false, None,
+            "tutu", None, "query", None, None, None, None, None, false, false, "Raw", None,
         );
 
         db.store_subscription(subscription_tutu.clone()).await?;
@@ -944,7 +950,7 @@ pub mod tests {
 
         // Create another subscription
         let subscription_tata = SubscriptionData::new(
-            "tata", None, "query", None, None, None, None, None, false, false, None,
+            "tata", None, "query", None, None, None, None, None, false, false, "Raw", None,
         );
 
         db.store_subscription(subscription_tata.clone()).await?;

--- a/common/src/database/postgres.rs
+++ b/common/src/database/postgres.rs
@@ -245,6 +245,7 @@ fn row_to_subscription(row: &Row) -> Result<SubscriptionData> {
         max_envelope_size.try_into()?,
         row.try_get("enabled")?,
         row.try_get("read_existing_events")?,
+        row.try_get("content_format")?,
         outputs,
     ))
 }
@@ -632,7 +633,8 @@ impl Database for PostgresDatabase {
             .execute(
                 r#"INSERT INTO subscriptions (uuid, version, name, uri, query,
                     heartbeat_interval, connection_retry_count, connection_retry_interval,
-                    max_time, max_envelope_size, enabled, read_existing_events, outputs)
+                    max_time, max_envelope_size, enabled, read_existing_events, content_format,
+                    outputs)
                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
                     ON CONFLICT (uuid) DO UPDATE SET 
                         version = excluded.version,
@@ -646,6 +648,7 @@ impl Database for PostgresDatabase {
                         max_envelope_size = excluded.max_envelope_size,
                         enabled = excluded.enabled,
                         read_existing_events = excluded.read_existing_events,
+                        content_format = excluded.content_format,
                         outputs = excluded.outputs"#,
                 &[
                     &subscription.uuid(),
@@ -660,6 +663,7 @@ impl Database for PostgresDatabase {
                     &max_envelope_size,
                     &subscription.enabled(),
                     &subscription.read_existing_events(),
+                    &subscription.content_format(),
                     &serde_json::to_string(subscription.outputs())?.as_str(),
                 ],
             )

--- a/common/src/database/postgres.rs
+++ b/common/src/database/postgres.rs
@@ -31,7 +31,7 @@ use crate::bookmark::BookmarkData;
 use crate::heartbeat::{HeartbeatKey, HeartbeatsCache};
 use crate::settings::PostgresSslMode;
 use crate::subscription::{
-    SubscriptionMachine, SubscriptionMachineState, SubscriptionStatsCounters,
+    ContentFormat, SubscriptionMachine, SubscriptionMachineState, SubscriptionStatsCounters,
 };
 use crate::{
     database::Database, heartbeat::HeartbeatData, settings::Postgres,
@@ -245,7 +245,7 @@ fn row_to_subscription(row: &Row) -> Result<SubscriptionData> {
         max_envelope_size.try_into()?,
         row.try_get("enabled")?,
         row.try_get("read_existing_events")?,
-        row.try_get("content_format")?,
+        ContentFormat::from_str(row.try_get("content_format")?)?,
         outputs,
     ))
 }
@@ -635,7 +635,7 @@ impl Database for PostgresDatabase {
                     heartbeat_interval, connection_retry_count, connection_retry_interval,
                     max_time, max_envelope_size, enabled, read_existing_events, content_format,
                     outputs)
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
                     ON CONFLICT (uuid) DO UPDATE SET 
                         version = excluded.version,
                         name = excluded.name,
@@ -663,7 +663,7 @@ impl Database for PostgresDatabase {
                     &max_envelope_size,
                     &subscription.enabled(),
                     &subscription.read_existing_events(),
-                    &subscription.content_format(),
+                    &subscription.content_format().to_string(),
                     &serde_json::to_string(subscription.outputs())?.as_str(),
                 ],
             )

--- a/common/src/database/schema/postgres/_006_add_content_format_field_in_subscriptions_table.rs
+++ b/common/src/database/schema/postgres/_006_add_content_format_field_in_subscriptions_table.rs
@@ -1,0 +1,30 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use deadpool_postgres::Transaction;
+
+use crate::{database::postgres::PostgresMigration, migration};
+
+pub(super) struct AddContentFormatFieldInSubscriptionsTable;
+migration!(
+    AddContentFormatFieldInSubscriptionsTable,
+    6,
+    "add content_format field in subscriptions table"
+);
+
+#[async_trait]
+impl PostgresMigration for AddContentFormatFieldInSubscriptionsTable {
+    async fn up(&self, tx: &mut Transaction) -> Result<()> {
+        tx.execute(
+            "ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS content_format TEXT DEFAULT 'RenderedText';",
+            &[],
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn down(&self, tx: &mut Transaction) -> Result<()> {
+        tx.execute("ALTER TABLE subscriptions DROP COLUMN IF EXISTS content_format", &[])
+            .await?;
+        Ok(())
+    }
+}

--- a/common/src/database/schema/postgres/mod.rs
+++ b/common/src/database/schema/postgres/mod.rs
@@ -8,6 +8,7 @@ use self::{
     _003_create_heartbeats_table::CreateHeartbeatsTable,
     _004_add_last_event_seen_field_in_heartbeats_table::AddLastEventSeenFieldInHeartbeatsTable,
     _005_add_uri_field_in_subscriptions_table::AddUriFieldInSubscriptionsTable,
+    _006_add_content_format_field_in_subscriptions_table::AddContentFormatFieldInSubscriptionsTable,
 };
 
 mod _001_create_subscriptions_table;
@@ -15,6 +16,7 @@ mod _002_create_bookmarks_table;
 mod _003_create_heartbeats_table;
 mod _004_add_last_event_seen_field_in_heartbeats_table;
 mod _005_add_uri_field_in_subscriptions_table;
+mod _006_add_content_format_field_in_subscriptions_table;
 
 pub fn register_migrations(postgres_db: &mut PostgresDatabase) {
     postgres_db.register_migration(Arc::new(CreateSubscriptionsTable));
@@ -22,4 +24,5 @@ pub fn register_migrations(postgres_db: &mut PostgresDatabase) {
     postgres_db.register_migration(Arc::new(CreateHeartbeatsTable));
     postgres_db.register_migration(Arc::new(AddLastEventSeenFieldInHeartbeatsTable));
     postgres_db.register_migration(Arc::new(AddUriFieldInSubscriptionsTable));
+    postgres_db.register_migration(Arc::new(AddContentFormatFieldInSubscriptionsTable));
 }

--- a/common/src/database/schema/sqlite/_006_add_content_format_field_in_subscriptions_table.rs
+++ b/common/src/database/schema/sqlite/_006_add_content_format_field_in_subscriptions_table.rs
@@ -1,0 +1,26 @@
+use anyhow::{anyhow, Result};
+use rusqlite::Connection;
+
+use crate::database::sqlite::SQLiteMigration;
+use crate::migration;
+
+pub(super) struct AddContentFormatFieldInSubscriptionsTable;
+migration!(
+    AddContentFormatFieldInSubscriptionsTable,
+    6,
+    "add content_format field in subscriptions table"
+);
+
+impl SQLiteMigration for AddContentFormatFieldInSubscriptionsTable {
+    fn up(&self, conn: &Connection) -> Result<()> {
+        conn.execute("ALTER TABLE subscriptions ADD COLUMN content_format TEXT DEFAULT 'RenderedText'", [])
+            .map_err(|err| anyhow!("SQLiteError: {}", err))?;
+        Ok(())
+    }
+
+    fn down(&self, conn: &Connection) -> Result<()> {
+        conn.execute("ALTER TABLE subscriptions DROP COLUMN content_format", [])
+            .map_err(|err| anyhow!("SQLiteError: {}", err))?;
+        Ok(())
+    }
+}

--- a/common/src/database/schema/sqlite/mod.rs
+++ b/common/src/database/schema/sqlite/mod.rs
@@ -8,6 +8,7 @@ use self::{
     _003_create_heartbeats_table::CreateHeartbeatsTable,
     _004_add_last_event_seen_field_in_heartbeats_table::AddLastEventSeenFieldInHeartbeatsTable,
     _005_add_uri_field_in_subscriptions_table::AddUriFieldInSubscriptionsTable,
+    _006_add_content_format_field_in_subscriptions_table::AddContentFormatFieldInSubscriptionsTable,
 };
 
 mod _001_create_subscriptions_table;
@@ -15,6 +16,7 @@ mod _002_create_bookmarks_table;
 mod _003_create_heartbeats_table;
 mod _004_add_last_event_seen_field_in_heartbeats_table;
 mod _005_add_uri_field_in_subscriptions_table;
+mod _006_add_content_format_field_in_subscriptions_table;
 
 pub fn register_migrations(sqlite_db: &mut SQLiteDatabase) {
     sqlite_db.register_migration(Arc::new(CreateSubscriptionsTable));
@@ -22,4 +24,5 @@ pub fn register_migrations(sqlite_db: &mut SQLiteDatabase) {
     sqlite_db.register_migration(Arc::new(CreateHeartbeatsTable));
     sqlite_db.register_migration(Arc::new(AddLastEventSeenFieldInHeartbeatsTable));
     sqlite_db.register_migration(Arc::new(AddUriFieldInSubscriptionsTable));
+    sqlite_db.register_migration(Arc::new(AddContentFormatFieldInSubscriptionsTable));
 }

--- a/common/src/database/sqlite.rs
+++ b/common/src/database/sqlite.rs
@@ -198,6 +198,7 @@ fn row_to_subscription(row: &Row) -> Result<SubscriptionData, rusqlite::Error> {
         row.get("max_envelope_size")?,
         row.get("enabled")?,
         row.get("read_existing_events")?,
+        row.get("content_format")?,
         outputs,
     ))
 }
@@ -567,10 +568,12 @@ impl Database for SQLiteDatabase {
                 conn.execute(
                     r#"INSERT INTO subscriptions (uuid, version, name, uri, query,
                     heartbeat_interval, connection_retry_count, connection_retry_interval,
-                    max_time, max_envelope_size, enabled, read_existing_events, outputs)
+                    max_time, max_envelope_size, enabled, read_existing_events, content_format,
+                    outputs)
                     VALUES (:uuid, :version, :name, :uri, :query,
                         :heartbeat_interval, :connection_retry_count, :connection_retry_interval,
-                        :max_time, :max_envelope_size, :enabled, :read_existing_events, :outputs)
+                        :max_time, :max_envelope_size, :enabled, :read_existing_events,
+                        :content_format, :outputs)
                     ON CONFLICT (uuid) DO UPDATE SET 
                         version = excluded.version,
                         name = excluded.name,
@@ -583,6 +586,7 @@ impl Database for SQLiteDatabase {
                         max_envelope_size = excluded.max_envelope_size,
                         enabled = excluded.enabled,
                         read_existing_events = excluded.read_existing_events,
+                        content_format = excluded.content_format,
                         outputs = excluded.outputs"#,
                     named_params! {
                         ":uuid": subscription.uuid(),
@@ -597,6 +601,7 @@ impl Database for SQLiteDatabase {
                         ":max_envelope_size": subscription.max_envelope_size(),
                         ":enabled": subscription.enabled(),
                         ":read_existing_events": subscription.read_existing_events(),
+                        ":content_format": subscription.content_format(),
                         ":outputs": serde_json::to_string(subscription.outputs())?,
                     },
                 )

--- a/common/src/subscription.rs
+++ b/common/src/subscription.rs
@@ -191,6 +191,31 @@ impl TryFrom<u8> for SubscriptionOutputFormat {
     }
 }
 
+#[derive(Debug, Serialize, Clone, Eq, PartialEq, Deserialize)]
+pub enum ContentFormat {
+    Raw,
+    RenderedText,
+}
+
+impl ContentFormat {
+    pub fn to_string(&self) -> String {
+        match self {
+            ContentFormat::Raw => "Raw".to_owned(),
+            ContentFormat::RenderedText => "RenderedText".to_owned(),
+        }
+    }
+
+    pub fn from_str(text: &str) -> Result<Self> {
+        if text == "Raw" {
+            Ok(ContentFormat::Raw)
+        } else if text == "RenderedText" {
+            Ok(ContentFormat::RenderedText)
+        } else {
+            bail!("Invalid ContentFormat string")
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Clone, Eq, Serialize, Deserialize)]
 pub struct SubscriptionData {
     #[serde(default = "new_uuid")]
@@ -207,7 +232,7 @@ pub struct SubscriptionData {
     max_envelope_size: u32,
     enabled: bool,
     read_existing_events: bool,
-    content_format: String,
+    content_format: ContentFormat,
     #[serde(default)]
     outputs: Vec<SubscriptionOutput>,
 }
@@ -243,7 +268,7 @@ impl Display for SubscriptionData {
         )?;
         writeln!(f, "\tMax envelope size: {} bytes", self.max_envelope_size())?;
         writeln!(f, "\tReadExistingEvents: {}", self.read_existing_events)?;
-        writeln!(f, "\tContent format: {}", self.content_format)?;
+        writeln!(f, "\tContent format: {}", self.content_format.to_string())?;
         if self.outputs().is_empty() {
             writeln!(f, "\tOutputs: None")?;
         } else {
@@ -271,7 +296,7 @@ impl SubscriptionData {
             max_envelope_size: 512_000,
             enabled: true,
             read_existing_events: false,
-            content_format: String::from("Raw"),
+            content_format: ContentFormat::Raw,
             outputs: Vec::new(),
         }
     }
@@ -287,7 +312,7 @@ impl SubscriptionData {
         max_envelope_size: Option<&u32>,
         enabled: bool,
         read_existing_events: bool,
-        content_format: &str,
+        content_format: ContentFormat,
         outputs: Option<Vec<SubscriptionOutput>>,
     ) -> Self {
         SubscriptionData {
@@ -321,7 +346,7 @@ impl SubscriptionData {
         max_envelope_size: u32,
         enabled: bool,
         read_existing_events: bool,
-        content_format: String,
+        content_format: ContentFormat,
         outputs: Vec<SubscriptionOutput>,
     ) -> Self {
         SubscriptionData {
@@ -479,11 +504,11 @@ impl SubscriptionData {
         self.update_version();
     }
 
-    pub fn content_format(&self) -> &str {
-        self.content_format.as_ref()
+    pub fn content_format(&self) -> &ContentFormat {
+        &self.content_format
     }
 
-    pub fn set_content_format(&mut self, content_format: String) {
+    pub fn set_content_format(&mut self, content_format: ContentFormat) {
         self.content_format = content_format;
         self.update_version();
     }

--- a/common/src/subscription.rs
+++ b/common/src/subscription.rs
@@ -207,6 +207,7 @@ pub struct SubscriptionData {
     max_envelope_size: u32,
     enabled: bool,
     read_existing_events: bool,
+    content_format: String,
     #[serde(default)]
     outputs: Vec<SubscriptionOutput>,
 }
@@ -242,6 +243,7 @@ impl Display for SubscriptionData {
         )?;
         writeln!(f, "\tMax envelope size: {} bytes", self.max_envelope_size())?;
         writeln!(f, "\tReadExistingEvents: {}", self.read_existing_events)?;
+        writeln!(f, "\tContent format: {}", self.content_format)?;
         if self.outputs().is_empty() {
             writeln!(f, "\tOutputs: None")?;
         } else {
@@ -269,6 +271,7 @@ impl SubscriptionData {
             max_envelope_size: 512_000,
             enabled: true,
             read_existing_events: false,
+            content_format: String::from("Raw"),
             outputs: Vec::new(),
         }
     }
@@ -284,6 +287,7 @@ impl SubscriptionData {
         max_envelope_size: Option<&u32>,
         enabled: bool,
         read_existing_events: bool,
+        content_format: &str,
         outputs: Option<Vec<SubscriptionOutput>>,
     ) -> Self {
         SubscriptionData {
@@ -299,6 +303,7 @@ impl SubscriptionData {
             max_envelope_size: *max_envelope_size.unwrap_or(&512_000),
             enabled,
             read_existing_events,
+            content_format: content_format.to_owned(),
             outputs: outputs.unwrap_or_default(),
         }
     }
@@ -316,6 +321,7 @@ impl SubscriptionData {
         max_envelope_size: u32,
         enabled: bool,
         read_existing_events: bool,
+        content_format: String,
         outputs: Vec<SubscriptionOutput>,
     ) -> Self {
         SubscriptionData {
@@ -331,6 +337,7 @@ impl SubscriptionData {
             max_envelope_size,
             enabled,
             read_existing_events,
+            content_format,
             outputs,
         }
     }
@@ -469,6 +476,15 @@ impl SubscriptionData {
 
     pub fn set_read_existing_events(&mut self, read_existing_events: bool) {
         self.read_existing_events = read_existing_events;
+        self.update_version();
+    }
+
+    pub fn content_format(&self) -> &str {
+        self.content_format.as_ref()
+    }
+
+    pub fn set_content_format(&mut self, content_format: String) {
+        self.content_format = content_format;
         self.update_version();
     }
 

--- a/doc/subscription.md
+++ b/doc/subscription.md
@@ -37,6 +37,7 @@ Subscriptions and their parameters are not defined in OpenWEC configuration file
 | `max_envelope_size` | No | 512000 | The maximum number of bytes in the SOAP envelope used to deliver the events. |
 | `enabled` | No | `False` | Whether the subscription is enabled or not. Not that a new subscription is **disabled** by default, and **can not** be enabled unless you configure at least one output. As a safe guard, subscriptions without outputs are ignored by openwec server. |
 | `read_existing_events` | No | `False` | If `True`, the event source should replay all possible events that match the filter and any events that subsequently occur for that event source.
+| `content_format` | No | `Raw` | This option determines whether rendering information are to be passed with events or not. `Raw` means that only event data will be passed without any rendering information, whereas `RenderedText` adds rendering information. |
 
 ## Subscription management
 
@@ -143,6 +144,7 @@ Subscription my-super-subscription
 	Max time without heartbeat/events: 600s
 	Max envelope size: 512000 bytes
 	ReadExistingEvents: false
+    ContentFormat: Raw
 	Outputs: None
 	Enabled: false
 
@@ -184,6 +186,7 @@ Subscription this-is-a-clone
 	Max time without heartbeat/events: 600s
 	Max envelope size: 512000 bytes
 	ReadExistingEvents: false
+    ContentFormat: Raw
 	Outputs: None
 	Enabled: false
 
@@ -212,7 +215,7 @@ These subscriptions can be imported in another openwec installation.
 
 ```
 $ openwec subscriptions export
-[{"uuid":"27D8CE0B-CAFE-44CA-9FE1-4B9D6EE45AE8","version":"3366A5BD-9E71-482E-9359-9505EA1F8400","name":"my-super-subscription","uri":"/new-uri","query":"<QueryList>\n    <Query Id=\"0\" Path=\"Application\">\n        <Select Path=\"Application\">*</Select>\n        <Select Path=\"Security\">*</Select>\n        <Select Path=\"Setup\">*</Select>\n        <Select Path=\"System\">*</Select>\n    </Query>\n</QueryList>\n","heartbeat_interval":600,"connection_retry_count":10,"connection_retry_interval":60,"max_time":600,"max_envelope_size":512000,"enabled":false,"read_existing_events":false,"outputs":[]},[...]]
+[{"uuid":"27D8CE0B-CAFE-44CA-9FE1-4B9D6EE45AE8","version":"3366A5BD-9E71-482E-9359-9505EA1F8400","name":"my-super-subscription","uri":"/new-uri","query":"<QueryList>\n    <Query Id=\"0\" Path=\"Application\">\n        <Select Path=\"Application\">*</Select>\n        <Select Path=\"Security\">*</Select>\n        <Select Path=\"Setup\">*</Select>\n        <Select Path=\"System\">*</Select>\n    </Query>\n</QueryList>\n","heartbeat_interval":600,"connection_retry_count":10,"connection_retry_interval":60,"max_time":600,"max_envelope_size":512000,"enabled":false,"read_existing_events":false,"content_format":"Raw","outputs":[]},[...]]
 ```
 
 ### `openwec subscriptions import`

--- a/server/src/event.rs
+++ b/server/src/event.rs
@@ -73,8 +73,8 @@ pub struct Event {
     system: System,
     #[serde(flatten, skip_serializing_if = "DataType::is_unknown")]
     data: DataType,
-    #[serde(rename = "RenderingInfo")]
-    rendering_info: RenderingInfo,
+    #[serde(rename = "RenderingInfo", skip_serializing_if = "Option::is_none")]
+    rendering_info: Option<RenderingInfo>,
     #[serde(rename = "OpenWEC")]
     additional: Additional,
 }
@@ -112,7 +112,7 @@ impl Event {
                     .context("Parsing failure in ProcessingErrorData")?
             } else if node.tag_name().name() == "RenderingInfo" {
                 event.rendering_info =
-                    RenderingInfo::from(&node).context("Parsing failure in RenderingInfo")?
+                    Some(RenderingInfo::from(&node).context("Parsing failure in RenderingInfo")?)
             } else if node.tag_name().name() == "SubscriptionBookmarkEvent" {
                 // Nothing to do, this node is present in the first received event (EventID 111)
             } else {
@@ -1088,7 +1088,7 @@ If this computer is a domain controller for the specified domain, it sets up the
     }
 
     const EVENT_111: &str = r#"<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-EventForwarder'/><EventID>111</EventID><TimeCreated SystemTime='2023-02-14T09:14:23.175Z'/><Computer>win10.windomain.local</Computer></System><SubscriptionBookmarkEvent><SubscriptionId></SubscriptionId></SubscriptionBookmarkEvent></Event>"#;
-    const EVENT_111_JSON: &str = r#"{"System":{"Provider":{"Name":"Microsoft-Windows-EventForwarder"},"EventID":111,"TimeCreated":"2023-02-14T09:14:23.175Z","Computer":"win10.windomain.local"},"RenderingInfo":{"Culture":""},"OpenWEC":{"IpAddress":"192.168.58.100","TimeReceived":"2022-12-14T16:07:02.156+00:00","Principal":"WIN10$@WINDOMAIN.LOCAL","Node":"other_node","Subscription":{"Uuid":"8B18D83D-2964-4F35-AC3B-6F4E6FFA727B","Version":"AD0D118F-31EF-4111-A0CA-D87249747278","Name":"Test","Uri":"/this/is/a/test"}}}"#;
+    const EVENT_111_JSON: &str = r#"{"System":{"Provider":{"Name":"Microsoft-Windows-EventForwarder"},"EventID":111,"TimeCreated":"2023-02-14T09:14:23.175Z","Computer":"win10.windomain.local"},"OpenWEC":{"IpAddress":"192.168.58.100","TimeReceived":"2022-12-14T16:07:02.156+00:00","Principal":"WIN10$@WINDOMAIN.LOCAL","Node":"other_node","Subscription":{"Uuid":"8B18D83D-2964-4F35-AC3B-6F4E6FFA727B","Version":"AD0D118F-31EF-4111-A0CA-D87249747278","Name":"Test","Uri":"/this/is/a/test"}}}"#;
 
     #[test]
     fn test_serialize_111() {

--- a/server/src/logic.rs
+++ b/server/src/logic.rs
@@ -126,10 +126,9 @@ async fn handle_enumerate(
             "Compression".to_string(),
             OptionSetValue::String("SLDC".to_string()),
         );
-        // TODO: Make content format an option
         options.insert(
             "ContentFormat".to_string(),
-            OptionSetValue::String("RenderedText".to_string()),
+            OptionSetValue::String(subscription_data.content_format().to_string()),
         );
         options.insert(
             "IgnoreChannelError".to_string(),


### PR DESCRIPTION
ContentFormat used to be hardcoded as "RenderedText". This means that all subscriptions retrieved RenderingInfo of all events.

RenderingInfo can be useful for event analysis but it increases event size. It seems necessary to make it configurable.

With this PR, ContentFormat is configurable and can have 2 values: "RenderedText" or "Raw".

See documentation for more details: [MS-WSMV] 3.1.4.1.30.1 Subscription Options :

> This option determines how the event data will be received by the event subscriber. If the
> value of this option is "RenderedText", both the event data and rendering information are
> passed, whereas event data is contained within the element <EventData> and rendering
> info is contained with the element <RenderingInfo>, so that the event can be displayed by
> the event subscriber according to a predefined format. The default value for this option is
> "Raw", which means that only event data will be passed without any rendering information.