### PR TITLE
Add IgnoreChannelError option to subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add OpenWEC node name (if configured) in JSON format output (#2)
-- Make ContentFormat configurable (#1)
+- Make ContentFormat of subscriptions configurable (#1)
+- Add IgnoreChannelError option to subscriptions (#6)
 
 ## [0.1.0] - 2023-05-30
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -28,7 +28,7 @@ pub async fn run(matches: ArgMatches, help_str: StyledStr) -> Result<()> {
     // Check that database schema is up to date
     match schema_is_up_to_date(db.clone()).await.context("Failed to check schema version") {
         Ok(true) => (),
-        Ok(false) => bail!("Schema needs to be updated. Please check migration guide and then run `openwec db upgrade`"),
+        Ok(false) => bail!("Schema needs to be updated. Please read the changelog and then run `openwec db upgrade`"),
         Err(err) => bail!("{:?}.\nHelp: You may need to run `openwec db init` to setup your database.", err),
     };
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -65,6 +65,9 @@ async fn main() {
                         .value_parser(["Raw", "RenderedText"])
                         .default_value("Raw")
                     )
+                    .arg(
+                        arg!(--"ignore-channel-error" <BOOL> "Configure clients to ignore filtering errors or not. Defaults to true").value_parser(value_parser!(bool)).default_value("true")
+                    )
                 )
                 .subcommand(
                     Command::new("edit")
@@ -162,6 +165,7 @@ async fn main() {
                     .arg(
                         arg!(--"disable" "Disable the subscription")
                     )
+                    .group(ArgGroup::new("subscription_status").args(["enable", "disable"]).required(false))
                     .arg(
                         arg!(--"content-format" <CONTENT_FORMAT> "If set to Raw, retrieve only the \
                         EventData part of events. If set to RenderedText, retrieve the \
@@ -169,7 +173,9 @@ async fn main() {
                         but can help with analysis.")
                         .value_parser(["Raw", "RenderedText"])
                     )
-                    .group(ArgGroup::new("subscription_status").args(["enable", "disable"]).required(false))
+                    .arg(
+                        arg!(--"ignore-channel-error" <BOOL> "Configure clients to ignore filtering errors or not.").value_parser(value_parser!(bool))
+                    )
                 )
                 .subcommand(
                     Command::new("show")

--- a/cli/src/subscriptions.rs
+++ b/cli/src/subscriptions.rs
@@ -320,6 +320,14 @@ async fn edit(db: &Db, matches: &ArgMatches) -> Result<()> {
         );
         subscription.set_content_format(content_format_t);
     }
+    if let Some(ignore_channel_error) = matches.get_one::<bool>("ignore-channel-error") {
+        debug!(
+            "Update ignore_channel_error from {} to {}",
+            subscription.ignore_channel_error(),
+            ignore_channel_error,
+        );
+        subscription.set_ignore_channel_error(*ignore_channel_error);
+    }
     info!(
         "Saving subscription {} ({})",
         subscription.name(),
@@ -364,6 +372,9 @@ async fn new(db: &Db, matches: &ArgMatches) -> Result<()> {
             .get_one::<bool>("read-existing-events")
             .expect("defaulted by clap"),
         content_format,
+        *matches
+            .get_one::<bool>("ignore-channel-error")
+            .expect("Defaulted by clap"),
         None,
     );
     debug!(
@@ -486,7 +497,6 @@ fn import_windows(mut reader: BufReader<File>) -> Result<Vec<SubscriptionData>> 
             let content_format = ContentFormat::from_str(node.text().unwrap())?;
             data.set_content_format(content_format);
         }
-
     }
 
     Ok(vec![data])

--- a/cli/src/subscriptions.rs
+++ b/cli/src/subscriptions.rs
@@ -11,6 +11,7 @@ use std::{
     collections::{HashMap, HashSet},
     fs::File,
     io::{BufReader, Read},
+    str::FromStr,
     time::SystemTime,
 };
 
@@ -312,7 +313,7 @@ async fn edit(db: &Db, matches: &ArgMatches) -> Result<()> {
     }
     if let Some(content_format) = matches.get_one::<String>("content-format") {
         let content_format_t =
-            ContentFormat::from_str(&content_format).context("Parse content-format argument")?;
+            ContentFormat::from_str(content_format).context("Parse content-format argument")?;
         debug!(
             "Update content_format from {} to {}",
             subscription.content_format().to_string(),

--- a/common/src/database/mod.rs
+++ b/common/src/database/mod.rs
@@ -164,6 +164,7 @@ pub mod tests {
             false,
             false,
             ContentFormat::Raw,
+            true,
             None,
         );
         db.store_subscription(subscription.clone()).await?;
@@ -175,6 +176,7 @@ pub mod tests {
         assert_eq!(toto.enabled(), false);
         assert_eq!(toto.read_existing_events(), false);
         assert_eq!(toto.content_format(), &ContentFormat::Raw);
+        assert_eq!(toto.ignore_channel_error(), true);
 
         let toto2 = db.get_subscription_by_identifier("toto").await?.unwrap();
         assert_eq!(toto, &toto2);
@@ -203,6 +205,7 @@ pub mod tests {
             true,
             true,
             ContentFormat::RenderedText,
+            false,
             Some(vec![
                 SubscriptionOutput::Files(
                     SubscriptionOutputFormat::Json,
@@ -227,6 +230,7 @@ pub mod tests {
         assert_eq!(tata.enabled(), true);
         assert_eq!(tata.read_existing_events(), true);
         assert_eq!(tata.content_format(), &ContentFormat::RenderedText);
+        assert_eq!(tata.ignore_channel_error(), false);
         assert_eq!(
             tata.outputs(),
             vec![
@@ -248,6 +252,7 @@ pub mod tests {
         tata.set_max_time(25000);
         tata.set_read_existing_events(false);
         tata.set_content_format(ContentFormat::Raw);
+        tata.set_ignore_channel_error(true);
         db.store_subscription(tata.clone()).await?;
 
         ensure!(db.get_subscriptions().await?.len() == 2);
@@ -259,6 +264,7 @@ pub mod tests {
         assert_eq!(tata2.max_time(), 25000);
         assert_eq!(tata2.read_existing_events(), false);
         assert_eq!(tata2.content_format(), &ContentFormat::Raw);
+        assert_eq!(tata2.ignore_channel_error(), true);
         assert!(tata2.version() != tata_save.version());
 
         db.delete_subscription(toto4.uuid()).await?;
@@ -292,8 +298,8 @@ pub mod tests {
             false,
             false,
             ContentFormat::Raw,
+            false,
             None,
-
         );
         db.store_subscription(subscription_tutu.clone()).await?;
         let subscription_titi = SubscriptionData::new(
@@ -308,6 +314,7 @@ pub mod tests {
             false,
             false,
             ContentFormat::RenderedText,
+            true,
             None,
         );
         db.store_subscription(subscription_titi.clone()).await?;
@@ -525,6 +532,7 @@ pub mod tests {
             false,
             false,
             ContentFormat::Raw,
+            true,
             None,
         );
 
@@ -646,6 +654,7 @@ pub mod tests {
             false,
             false,
             ContentFormat::RenderedText,
+            false,
             None,
         );
 
@@ -790,6 +799,7 @@ pub mod tests {
             false,
             false,
             ContentFormat::Raw,
+            true,
             None,
         );
 
@@ -1019,6 +1029,7 @@ pub mod tests {
             false,
             false,
             ContentFormat::Raw,
+            false,
             None,
         );
 

--- a/common/src/database/postgres.rs
+++ b/common/src/database/postgres.rs
@@ -5,19 +5,19 @@
 // permission notice:
 //
 //       The MIT License (MIT)
-//       
+//
 //       Copyright (c) 2015 Skyler Lipthay
-//       
+//
 //       Permission is hereby granted, free of charge, to any person obtaining a copy
 //       of this software and associated documentation files (the "Software"), to deal
 //       in the Software without restriction, including without limitation the rights
 //       to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 //       copies of the Software, and to permit persons to whom the Software is
 //       furnished to do so, subject to the following conditions:
-//       
+//
 //       The above copyright notice and this permission notice shall be included in all
 //       copies or substantial portions of the Software.
-//       
+//
 //       THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 //       IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 //       FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -246,6 +246,7 @@ fn row_to_subscription(row: &Row) -> Result<SubscriptionData> {
         row.try_get("enabled")?,
         row.try_get("read_existing_events")?,
         ContentFormat::from_str(row.try_get("content_format")?)?,
+        row.try_get("ignore_channel_error")?,
         outputs,
     ))
 }
@@ -633,9 +634,8 @@ impl Database for PostgresDatabase {
             .execute(
                 r#"INSERT INTO subscriptions (uuid, version, name, uri, query,
                     heartbeat_interval, connection_retry_count, connection_retry_interval,
-                    max_time, max_envelope_size, enabled, read_existing_events, content_format,
-                    outputs)
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+                    max_time, max_envelope_size, enabled, read_existing_events, content_format, ignore_channel_error, outputs)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
                     ON CONFLICT (uuid) DO UPDATE SET 
                         version = excluded.version,
                         name = excluded.name,
@@ -649,6 +649,7 @@ impl Database for PostgresDatabase {
                         enabled = excluded.enabled,
                         read_existing_events = excluded.read_existing_events,
                         content_format = excluded.content_format,
+                        ignore_channel_error = excluded.ignore_channel_error,
                         outputs = excluded.outputs"#,
                 &[
                     &subscription.uuid(),
@@ -664,6 +665,7 @@ impl Database for PostgresDatabase {
                     &subscription.enabled(),
                     &subscription.read_existing_events(),
                     &subscription.content_format().to_string(),
+                    &subscription.ignore_channel_error(),
                     &serde_json::to_string(subscription.outputs())?.as_str(),
                 ],
             )

--- a/common/src/database/postgres.rs
+++ b/common/src/database/postgres.rs
@@ -44,6 +44,7 @@ use log::{error, warn};
 use openssl::ssl::{SslConnector, SslMethod};
 use postgres_openssl::MakeTlsConnector;
 use std::collections::btree_map::Entry::Vacant;
+use std::str::FromStr;
 use std::{
     collections::{BTreeMap, BTreeSet},
     sync::Arc,

--- a/common/src/database/schema/postgres/_007_add_ignore_channel_error_field_in_subscriptions_table.rs
+++ b/common/src/database/schema/postgres/_007_add_ignore_channel_error_field_in_subscriptions_table.rs
@@ -1,0 +1,33 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use deadpool_postgres::Transaction;
+
+use crate::{database::postgres::PostgresMigration, migration};
+
+pub(super) struct AddIgnoreChannelErrorFieldInSubscriptionsTable;
+migration!(
+    AddIgnoreChannelErrorFieldInSubscriptionsTable,
+    7,
+    "add ignore_channel_error field in subscriptions table"
+);
+
+#[async_trait]
+impl PostgresMigration for AddIgnoreChannelErrorFieldInSubscriptionsTable {
+    async fn up(&self, tx: &mut Transaction) -> Result<()> {
+        tx.execute(
+            "ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS ignore_channel_error BOOLEAN DEFAULT true;",
+            &[],
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn down(&self, tx: &mut Transaction) -> Result<()> {
+        tx.execute(
+            "ALTER TABLE subscriptions DROP COLUMN IF EXISTS ignore_channel_error",
+            &[],
+        )
+        .await?;
+        Ok(())
+    }
+}

--- a/common/src/database/schema/postgres/mod.rs
+++ b/common/src/database/schema/postgres/mod.rs
@@ -9,6 +9,7 @@ use self::{
     _004_add_last_event_seen_field_in_heartbeats_table::AddLastEventSeenFieldInHeartbeatsTable,
     _005_add_uri_field_in_subscriptions_table::AddUriFieldInSubscriptionsTable,
     _006_add_content_format_field_in_subscriptions_table::AddContentFormatFieldInSubscriptionsTable,
+    _007_add_ignore_channel_error_field_in_subscriptions_table::AddIgnoreChannelErrorFieldInSubscriptionsTable,
 };
 
 mod _001_create_subscriptions_table;
@@ -17,6 +18,7 @@ mod _003_create_heartbeats_table;
 mod _004_add_last_event_seen_field_in_heartbeats_table;
 mod _005_add_uri_field_in_subscriptions_table;
 mod _006_add_content_format_field_in_subscriptions_table;
+mod _007_add_ignore_channel_error_field_in_subscriptions_table;
 
 pub fn register_migrations(postgres_db: &mut PostgresDatabase) {
     postgres_db.register_migration(Arc::new(CreateSubscriptionsTable));
@@ -25,4 +27,5 @@ pub fn register_migrations(postgres_db: &mut PostgresDatabase) {
     postgres_db.register_migration(Arc::new(AddLastEventSeenFieldInHeartbeatsTable));
     postgres_db.register_migration(Arc::new(AddUriFieldInSubscriptionsTable));
     postgres_db.register_migration(Arc::new(AddContentFormatFieldInSubscriptionsTable));
+    postgres_db.register_migration(Arc::new(AddIgnoreChannelErrorFieldInSubscriptionsTable));
 }

--- a/common/src/database/schema/sqlite/_007_add_ignore_channel_error_field_in_subscriptions_table.rs
+++ b/common/src/database/schema/sqlite/_007_add_ignore_channel_error_field_in_subscriptions_table.rs
@@ -1,0 +1,32 @@
+use anyhow::{anyhow, Result};
+use rusqlite::Connection;
+
+use crate::database::sqlite::SQLiteMigration;
+use crate::migration;
+
+pub(super) struct AddIgnoreChannelErrorFieldInSubscriptionsTable;
+migration!(
+    AddIgnoreChannelErrorFieldInSubscriptionsTable,
+    7,
+    "add ignore_channel_error field in subscriptions table"
+);
+
+impl SQLiteMigration for AddIgnoreChannelErrorFieldInSubscriptionsTable {
+    fn up(&self, conn: &Connection) -> Result<()> {
+        conn.execute(
+            "ALTER TABLE subscriptions ADD COLUMN ignore_channel_error INTEGER DEFAULT 1",
+            [],
+        )
+        .map_err(|err| anyhow!("SQLiteError: {}", err))?;
+        Ok(())
+    }
+
+    fn down(&self, conn: &Connection) -> Result<()> {
+        conn.execute(
+            "ALTER TABLE subscriptions DROP COLUMN ignore_channel_error",
+            [],
+        )
+        .map_err(|err| anyhow!("SQLiteError: {}", err))?;
+        Ok(())
+    }
+}

--- a/common/src/database/schema/sqlite/mod.rs
+++ b/common/src/database/schema/sqlite/mod.rs
@@ -9,6 +9,7 @@ use self::{
     _004_add_last_event_seen_field_in_heartbeats_table::AddLastEventSeenFieldInHeartbeatsTable,
     _005_add_uri_field_in_subscriptions_table::AddUriFieldInSubscriptionsTable,
     _006_add_content_format_field_in_subscriptions_table::AddContentFormatFieldInSubscriptionsTable,
+    _007_add_ignore_channel_error_field_in_subscriptions_table::AddIgnoreChannelErrorFieldInSubscriptionsTable,
 };
 
 mod _001_create_subscriptions_table;
@@ -17,6 +18,7 @@ mod _003_create_heartbeats_table;
 mod _004_add_last_event_seen_field_in_heartbeats_table;
 mod _005_add_uri_field_in_subscriptions_table;
 mod _006_add_content_format_field_in_subscriptions_table;
+mod _007_add_ignore_channel_error_field_in_subscriptions_table;
 
 pub fn register_migrations(sqlite_db: &mut SQLiteDatabase) {
     sqlite_db.register_migration(Arc::new(CreateSubscriptionsTable));
@@ -25,4 +27,5 @@ pub fn register_migrations(sqlite_db: &mut SQLiteDatabase) {
     sqlite_db.register_migration(Arc::new(AddLastEventSeenFieldInHeartbeatsTable));
     sqlite_db.register_migration(Arc::new(AddUriFieldInSubscriptionsTable));
     sqlite_db.register_migration(Arc::new(AddContentFormatFieldInSubscriptionsTable));
+    sqlite_db.register_migration(Arc::new(AddIgnoreChannelErrorFieldInSubscriptionsTable));
 }

--- a/common/src/database/sqlite.rs
+++ b/common/src/database/sqlite.rs
@@ -200,6 +200,7 @@ fn row_to_subscription(row: &Row) -> Result<SubscriptionData, rusqlite::Error> {
         row.get("enabled")?,
         row.get("read_existing_events")?,
         content_format,
+        row.get("ignore_channel_error")?,
         outputs,
     ))
 }
@@ -569,12 +570,10 @@ impl Database for SQLiteDatabase {
                 conn.execute(
                     r#"INSERT INTO subscriptions (uuid, version, name, uri, query,
                     heartbeat_interval, connection_retry_count, connection_retry_interval,
-                    max_time, max_envelope_size, enabled, read_existing_events, content_format,
-                    outputs)
+                    max_time, max_envelope_size, enabled, read_existing_events, content_format, ignore_channel_error, outputs)
                     VALUES (:uuid, :version, :name, :uri, :query,
                         :heartbeat_interval, :connection_retry_count, :connection_retry_interval,
-                        :max_time, :max_envelope_size, :enabled, :read_existing_events,
-                        :content_format, :outputs)
+                        :max_time, :max_envelope_size, :enabled, :read_existing_events, :content_format, :ignore_channel_error, :outputs)
                     ON CONFLICT (uuid) DO UPDATE SET 
                         version = excluded.version,
                         name = excluded.name,
@@ -588,6 +587,7 @@ impl Database for SQLiteDatabase {
                         enabled = excluded.enabled,
                         read_existing_events = excluded.read_existing_events,
                         content_format = excluded.content_format,
+                        ignore_channel_error = excluded.ignore_channel_error,
                         outputs = excluded.outputs"#,
                     named_params! {
                         ":uuid": subscription.uuid(),
@@ -603,6 +603,7 @@ impl Database for SQLiteDatabase {
                         ":enabled": subscription.enabled(),
                         ":read_existing_events": subscription.read_existing_events(),
                         ":content_format": subscription.content_format().to_string(),
+                        ":ignore_channel_error": subscription.ignore_channel_error(),
                         ":outputs": serde_json::to_string(subscription.outputs())?,
                     },
                 )

--- a/common/src/database/sqlite.rs
+++ b/common/src/database/sqlite.rs
@@ -33,6 +33,7 @@ use rusqlite::types::Type;
 use rusqlite::{named_params, params, Connection, OptionalExtension, Row};
 use std::collections::btree_map::Entry::Vacant;
 use std::collections::{BTreeMap, BTreeSet};
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::SystemTime;
 

--- a/common/src/subscription.rs
+++ b/common/src/subscription.rs
@@ -233,6 +233,7 @@ pub struct SubscriptionData {
     enabled: bool,
     read_existing_events: bool,
     content_format: ContentFormat,
+    ignore_channel_error: bool,
     #[serde(default)]
     outputs: Vec<SubscriptionOutput>,
 }
@@ -268,7 +269,8 @@ impl Display for SubscriptionData {
         )?;
         writeln!(f, "\tMax envelope size: {} bytes", self.max_envelope_size())?;
         writeln!(f, "\tReadExistingEvents: {}", self.read_existing_events)?;
-        writeln!(f, "\tContent format: {}", self.content_format.to_string())?;
+        writeln!(f, "\tContent format: {}", self.content_format().to_string())?;
+        writeln!(f, "\tIgnore channel error: {}", self.ignore_channel_error())?;
         if self.outputs().is_empty() {
             writeln!(f, "\tOutputs: None")?;
         } else {
@@ -297,6 +299,7 @@ impl SubscriptionData {
             enabled: true,
             read_existing_events: false,
             content_format: ContentFormat::Raw,
+            ignore_channel_error: true,
             outputs: Vec::new(),
         }
     }
@@ -313,6 +316,7 @@ impl SubscriptionData {
         enabled: bool,
         read_existing_events: bool,
         content_format: ContentFormat,
+        ignore_channel_error: bool,
         outputs: Option<Vec<SubscriptionOutput>>,
     ) -> Self {
         SubscriptionData {
@@ -328,7 +332,8 @@ impl SubscriptionData {
             max_envelope_size: *max_envelope_size.unwrap_or(&512_000),
             enabled,
             read_existing_events,
-            content_format: content_format.to_owned(),
+            content_format,
+            ignore_channel_error,
             outputs: outputs.unwrap_or_default(),
         }
     }
@@ -347,6 +352,7 @@ impl SubscriptionData {
         enabled: bool,
         read_existing_events: bool,
         content_format: ContentFormat,
+        ignore_channel_error: bool,
         outputs: Vec<SubscriptionOutput>,
     ) -> Self {
         SubscriptionData {
@@ -363,6 +369,7 @@ impl SubscriptionData {
             enabled,
             read_existing_events,
             content_format,
+            ignore_channel_error,
             outputs,
         }
     }
@@ -510,6 +517,15 @@ impl SubscriptionData {
 
     pub fn set_content_format(&mut self, content_format: ContentFormat) {
         self.content_format = content_format;
+        self.update_version();
+    }
+
+    pub fn ignore_channel_error(&self) -> bool {
+        self.ignore_channel_error
+    }
+
+    pub fn set_ignore_channel_error(&mut self, ignore_channel_error: bool) {
+        self.ignore_channel_error = ignore_channel_error;
         self.update_version();
     }
 

--- a/common/src/subscription.rs
+++ b/common/src/subscription.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     fmt::{Display, Formatter},
+    str::FromStr,
 };
 
 use crate::utils::new_uuid;
@@ -197,18 +198,22 @@ pub enum ContentFormat {
     RenderedText,
 }
 
-impl ContentFormat {
-    pub fn to_string(&self) -> String {
+impl Display for ContentFormat {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
-            ContentFormat::Raw => "Raw".to_owned(),
-            ContentFormat::RenderedText => "RenderedText".to_owned(),
+            ContentFormat::Raw => write!(f, "Raw"),
+            ContentFormat::RenderedText => write!(f, "RenderedText"),
         }
     }
+}
 
-    pub fn from_str(text: &str) -> Result<Self> {
-        if text == "Raw" {
+impl FromStr for ContentFormat {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "Raw" {
             Ok(ContentFormat::Raw)
-        } else if text == "RenderedText" {
+        } else if s == "RenderedText" {
             Ok(ContentFormat::RenderedText)
         } else {
             bail!("Invalid ContentFormat string")
@@ -269,7 +274,7 @@ impl Display for SubscriptionData {
         )?;
         writeln!(f, "\tMax envelope size: {} bytes", self.max_envelope_size())?;
         writeln!(f, "\tReadExistingEvents: {}", self.read_existing_events)?;
-        writeln!(f, "\tContent format: {}", self.content_format().to_string())?;
+        writeln!(f, "\tContent format: {}", self.content_format())?;
         writeln!(f, "\tIgnore channel error: {}", self.ignore_channel_error())?;
         if self.outputs().is_empty() {
             writeln!(f, "\tOutputs: None")?;
@@ -572,12 +577,7 @@ impl SubscriptionData {
     }
 
     pub fn is_active(&self) -> bool {
-        self.enabled()
-            && self
-                .outputs()
-                .iter()
-                .find(|output| output.is_enabled())
-                .is_some()
+        self.enabled() && self.outputs().iter().any(|output| output.is_enabled())
     }
 }
 

--- a/doc/subscription.md
+++ b/doc/subscription.md
@@ -36,8 +36,9 @@ Subscriptions and their parameters are not defined in OpenWEC configuration file
 | `max_time` | No | 30 | The maximum time, in seconds, that the client should aggregate new events before sending them. |
 | `max_envelope_size` | No | 512000 | The maximum number of bytes in the SOAP envelope used to deliver the events. |
 | `enabled` | No | `False` | Whether the subscription is enabled or not. Not that a new subscription is **disabled** by default, and **can not** be enabled unless you configure at least one output. As a safe guard, subscriptions without outputs are ignored by openwec server. |
-| `read_existing_events` | No | `False` | If `True`, the event source should replay all possible events that match the filter and any events that subsequently occur for that event source.
+| `read_existing_events` | No | `False` | If `True`, the event source should replay all possible events that match the filter and any events that subsequently occur for that event source. |
 | `content_format` | No | `Raw` | This option determines whether rendering information are to be passed with events or not. `Raw` means that only event data will be passed without any rendering information, whereas `RenderedText` adds rendering information. |
+| `ignore_channel_error` | No | `true` | This option determines if various filtering options resulting in errors are to result in termination of the processing by clients. |
 
 ## Subscription management
 
@@ -144,7 +145,8 @@ Subscription my-super-subscription
 	Max time without heartbeat/events: 600s
 	Max envelope size: 512000 bytes
 	ReadExistingEvents: false
-    ContentFormat: Raw
+	ContentFormat: Raw
+	IgnoreChannelError: true
 	Outputs: None
 	Enabled: false
 
@@ -186,7 +188,8 @@ Subscription this-is-a-clone
 	Max time without heartbeat/events: 600s
 	Max envelope size: 512000 bytes
 	ReadExistingEvents: false
-    ContentFormat: Raw
+	ContentFormat: Raw
+	IgnoreChannelError: true
 	Outputs: None
 	Enabled: false
 
@@ -215,7 +218,7 @@ These subscriptions can be imported in another openwec installation.
 
 ```
 $ openwec subscriptions export
-[{"uuid":"27D8CE0B-CAFE-44CA-9FE1-4B9D6EE45AE8","version":"3366A5BD-9E71-482E-9359-9505EA1F8400","name":"my-super-subscription","uri":"/new-uri","query":"<QueryList>\n    <Query Id=\"0\" Path=\"Application\">\n        <Select Path=\"Application\">*</Select>\n        <Select Path=\"Security\">*</Select>\n        <Select Path=\"Setup\">*</Select>\n        <Select Path=\"System\">*</Select>\n    </Query>\n</QueryList>\n","heartbeat_interval":600,"connection_retry_count":10,"connection_retry_interval":60,"max_time":600,"max_envelope_size":512000,"enabled":false,"read_existing_events":false,"content_format":"Raw","outputs":[]},[...]]
+[{"uuid":"27D8CE0B-CAFE-44CA-9FE1-4B9D6EE45AE8","version":"3366A5BD-9E71-482E-9359-9505EA1F8400","name":"my-super-subscription","uri":"/new-uri","query":"<QueryList>\n    <Query Id=\"0\" Path=\"Application\">\n        <Select Path=\"Application\">*</Select>\n        <Select Path=\"Security\">*</Select>\n        <Select Path=\"Setup\">*</Select>\n        <Select Path=\"System\">*</Select>\n    </Query>\n</QueryList>\n","heartbeat_interval":600,"connection_retry_count":10,"connection_retry_interval":60,"max_time":600,"max_envelope_size":512000,"enabled":false,"read_existing_events":false,"content_format":"Raw","ignore_channel_error":true,"outputs":[]},[...]]
 ```
 
 ### `openwec subscriptions import`

--- a/server/src/logic.rs
+++ b/server/src/logic.rs
@@ -132,7 +132,7 @@ async fn handle_enumerate(
         );
         options.insert(
             "IgnoreChannelError".to_string(),
-            OptionSetValue::Boolean(true),
+            OptionSetValue::Boolean(subscription_data.ignore_channel_error()),
         );
         options.insert("CDATA".to_string(), OptionSetValue::Boolean(true));
 


### PR DESCRIPTION
The Ignore Channel Error option allows you to decide whether a client should continue processing a subscription if an error occurs within its channel filters :
* `true`: the error is ignored (default)
* `false`: the processing stops if an error occurs

Prior to this update, this option was hardcoded to `true`.

See documentation for more details: [MS-WSMV] 3.1.4.1.30.1 Subscription Options :

    This option determines if various filtering options resulting in errors in different channels
    are to result in termination of the processing. It has the xsi:nil attribute associated with it, 
    whose value is set to "true", meaning that the filtering errors in different channels MUST be
    ignored by the subscription service and processing SHOULD continue.
