### PR TITLE
Add Kerberos principals filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add OpenWEC node name (if configured) in JSON format output (#2)
 - Make ContentFormat of subscriptions configurable (#1)
 - Add IgnoreChannelError option to subscriptions (#6)
+- Add Kerberos principals filter to subscriptions (#18)
 
 ## [0.1.0] - 2023-05-30
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -131,6 +131,35 @@ async fn main() {
                             .arg(arg!(<index> "Index of the output to disable").value_parser(value_parser!(usize)))
                         )
                     )
+                    .subcommand(
+                        Command::new("filter")
+                        .about("Manage the principals filter of a subscription.")
+                        .subcommand(
+                            Command::new("set")
+                            .about("Set the principals filter.")
+                            .arg(arg!(<operation> "Possible operations are: 'none' (don't filter), 'only' (only apply this subscription to the given principals), 'except' (apply this subcription to everyone except the given principals).").value_parser(["none", "only", "except"]).required(true))
+                            .arg(arg!(<principals> ... "Principals to filter. The comparison of principal names is case-sensitive.").action(ArgAction::Append).required(false))
+                        )
+                        .subcommand(
+                            Command::new("princs")
+                            .about("Manage the principals of the filter.")
+                            .subcommand(
+                                Command::new("add")
+                                .about("Add a principal (case-sensitive)")
+                                .arg(arg!(<principal> "Principal to add. The comparison of principal names is case-sensitive."))
+                            )
+                            .subcommand(
+                                Command::new("delete")
+                                .about("Delete a principal (case-sensitive)")
+                                .arg(arg!(<principal> "Principal to delete. The comparison of principal names is case-sensitive."))
+                            )
+                            .subcommand(
+                                Command::new("set")
+                                .about("Set the principals (case-sensitive)")
+                                .arg(arg!(<principals> ... "Principals to filter. The comparison of principal names is case-sensitive.").action(ArgAction::Append).required(true))
+                            )
+                        )
+                    )
                     .arg(arg!(-q --query <QUERY> "File containing the query (XML format)"))
                     .arg(arg!(-r --rename <NAME> "Rename the subscription"))
                     .arg(

--- a/common/src/database/schema/postgres/_008_add_princs_filter_fields_in_subscriptions_table.rs
+++ b/common/src/database/schema/postgres/_008_add_princs_filter_fields_in_subscriptions_table.rs
@@ -1,0 +1,43 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use deadpool_postgres::Transaction;
+
+use crate::{database::postgres::PostgresMigration, migration};
+
+pub(super) struct AddPrincsFilterFieldsInSubscriptionsTable;
+migration!(
+    AddPrincsFilterFieldsInSubscriptionsTable,
+    8,
+    "add princs_filter fields in subscriptions table"
+);
+
+#[async_trait]
+impl PostgresMigration for AddPrincsFilterFieldsInSubscriptionsTable {
+    async fn up(&self, tx: &mut Transaction) -> Result<()> {
+        tx.execute(
+            "ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS princs_filter_op TEXT;",
+            &[],
+        )
+        .await?;
+        tx.execute(
+            "ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS princs_filter_value TEXT;",
+            &[],
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn down(&self, tx: &mut Transaction) -> Result<()> {
+        tx.execute(
+            "ALTER TABLE subscriptions DROP COLUMN IF EXISTS princs_filter_op",
+            &[],
+        )
+        .await?;
+        tx.execute(
+            "ALTER TABLE subscriptions DROP COLUMN IF EXISTS princs_filter_value",
+            &[],
+        )
+        .await?;
+        Ok(())
+    }
+}

--- a/common/src/database/schema/postgres/mod.rs
+++ b/common/src/database/schema/postgres/mod.rs
@@ -10,6 +10,7 @@ use self::{
     _005_add_uri_field_in_subscriptions_table::AddUriFieldInSubscriptionsTable,
     _006_add_content_format_field_in_subscriptions_table::AddContentFormatFieldInSubscriptionsTable,
     _007_add_ignore_channel_error_field_in_subscriptions_table::AddIgnoreChannelErrorFieldInSubscriptionsTable,
+    _008_add_princs_filter_fields_in_subscriptions_table::AddPrincsFilterFieldsInSubscriptionsTable,
 };
 
 mod _001_create_subscriptions_table;
@@ -19,6 +20,7 @@ mod _004_add_last_event_seen_field_in_heartbeats_table;
 mod _005_add_uri_field_in_subscriptions_table;
 mod _006_add_content_format_field_in_subscriptions_table;
 mod _007_add_ignore_channel_error_field_in_subscriptions_table;
+mod _008_add_princs_filter_fields_in_subscriptions_table;
 
 pub fn register_migrations(postgres_db: &mut PostgresDatabase) {
     postgres_db.register_migration(Arc::new(CreateSubscriptionsTable));
@@ -28,4 +30,5 @@ pub fn register_migrations(postgres_db: &mut PostgresDatabase) {
     postgres_db.register_migration(Arc::new(AddUriFieldInSubscriptionsTable));
     postgres_db.register_migration(Arc::new(AddContentFormatFieldInSubscriptionsTable));
     postgres_db.register_migration(Arc::new(AddIgnoreChannelErrorFieldInSubscriptionsTable));
+    postgres_db.register_migration(Arc::new(AddPrincsFilterFieldsInSubscriptionsTable));
 }

--- a/common/src/database/schema/sqlite/_008_add_princs_filter_fields_in_subscriptions_table.rs
+++ b/common/src/database/schema/sqlite/_008_add_princs_filter_fields_in_subscriptions_table.rs
@@ -1,0 +1,39 @@
+use anyhow::{anyhow, Result};
+use rusqlite::Connection;
+
+use crate::database::sqlite::SQLiteMigration;
+use crate::migration;
+
+pub(super) struct AddPrincsFilterFieldsInSubscriptionsTable;
+migration!(
+    AddPrincsFilterFieldsInSubscriptionsTable,
+    8,
+    "add princs_filter fields in subscriptions table"
+);
+
+impl SQLiteMigration for AddPrincsFilterFieldsInSubscriptionsTable {
+    fn up(&self, conn: &Connection) -> Result<()> {
+        conn.execute(
+            "ALTER TABLE subscriptions ADD COLUMN princs_filter_op TEXT",
+            [],
+        )
+        .map_err(|err| anyhow!("SQLiteError: {}", err))?;
+        conn.execute(
+            "ALTER TABLE subscriptions ADD COLUMN princs_filter_value TEXT",
+            [],
+        )
+        .map_err(|err| anyhow!("SQLiteError: {}", err))?;
+        Ok(())
+    }
+
+    fn down(&self, conn: &Connection) -> Result<()> {
+        conn.execute("ALTER TABLE subscriptions DROP COLUMN princs_filter_op", [])
+            .map_err(|err| anyhow!("SQLiteError: {}", err))?;
+        conn.execute(
+            "ALTER TABLE subscriptions DROP COLUMN princs_filter_value",
+            [],
+        )
+        .map_err(|err| anyhow!("SQLiteError: {}", err))?;
+        Ok(())
+    }
+}

--- a/common/src/database/schema/sqlite/mod.rs
+++ b/common/src/database/schema/sqlite/mod.rs
@@ -10,6 +10,7 @@ use self::{
     _005_add_uri_field_in_subscriptions_table::AddUriFieldInSubscriptionsTable,
     _006_add_content_format_field_in_subscriptions_table::AddContentFormatFieldInSubscriptionsTable,
     _007_add_ignore_channel_error_field_in_subscriptions_table::AddIgnoreChannelErrorFieldInSubscriptionsTable,
+    _008_add_princs_filter_fields_in_subscriptions_table::AddPrincsFilterFieldsInSubscriptionsTable,
 };
 
 mod _001_create_subscriptions_table;
@@ -19,6 +20,7 @@ mod _004_add_last_event_seen_field_in_heartbeats_table;
 mod _005_add_uri_field_in_subscriptions_table;
 mod _006_add_content_format_field_in_subscriptions_table;
 mod _007_add_ignore_channel_error_field_in_subscriptions_table;
+mod _008_add_princs_filter_fields_in_subscriptions_table;
 
 pub fn register_migrations(sqlite_db: &mut SQLiteDatabase) {
     sqlite_db.register_migration(Arc::new(CreateSubscriptionsTable));
@@ -28,4 +30,5 @@ pub fn register_migrations(sqlite_db: &mut SQLiteDatabase) {
     sqlite_db.register_migration(Arc::new(AddUriFieldInSubscriptionsTable));
     sqlite_db.register_migration(Arc::new(AddContentFormatFieldInSubscriptionsTable));
     sqlite_db.register_migration(Arc::new(AddIgnoreChannelErrorFieldInSubscriptionsTable));
+    sqlite_db.register_migration(Arc::new(AddPrincsFilterFieldsInSubscriptionsTable));
 }

--- a/doc/issues.md
+++ b/doc/issues.md
@@ -54,7 +54,7 @@ To support this, we would need to enable users to configure a list of Kerberos p
 
 ## Limit subscriptions to a subset of machines
 
-In Microsoft implementation, subscriptions can be set to a group of machines. The only "clean" way to do this is to parse the PAC contained in the Kerberos service ticket provided by the machine, but this does not seem to be supported by GSSAPI. We could alternatively limit a subscription to a list of Kerberos principals.
+The Microsoft implementation allows subscriptions to be set for a group of machines. The only "clean" way to do this is to parse the PAC contained in the machine's Kerberos service ticket, but this does not appear to be supported by GSSAPI. Alternatively, OpenWEC implements filters using the Kerberos principal names of machines, allowing you to allow or deny a set of principals to "see"/"use" a subscription.
 
 In any case, it won't work with an intermediate forwarder.
 

--- a/doc/subscription.md
+++ b/doc/subscription.md
@@ -62,6 +62,20 @@ In its configuration UI, Microsoft WEC enables users to choose between three eve
 
 In its documentation, Microsoft states that Normal mode uses a Pull delivery mode (meaning that its the collector who connects to Windows machines and retrieve their event logs). It seems to be a mistake, as the exported configuration of a subscription configured in Normal mode clearly specifies that it is SourceInitiated in Push mode.
 
+## Principals filter
+
+It is possible to filter the client Kerberos principals that can see a subscription. The comparison is **case-sensitive**.
+
+There are three filtering modes:
+* `None` (default): no filtering based on Kerberos principal
+* `Only [princ, ...]`: the subscription will only be shown to the listed principals
+* `Except [princ, ...]`: the subscription will be shown to everyone except the listed principals
+
+The principals filter can be configured using openwec cli:
+*  `openwec subscriptions edit <subscription> filter set <mode> [princ, ...]` configures the principals filter.
+*  `openwec subscriptions edit <subscription> filter princs {add,delete,set} [princ, ...]` manages the principals in the filter.
+
+
 ## Available commands
 
 ### `openwec subscriptions`
@@ -112,7 +126,7 @@ This command enables you to edit an already existing subscription.
 
 You must provide the identifier of the subscription to edit, which can be either its `name` or its `uuid`.
 
-You may edit every parameters of the subscription, even its name.
+You can edit every parameters of the subscription, even its name.
 
 You should be very careful when editing a subscription query, especially when adding new event log channels (see [Query known issues](query.md#known-issues)).
 
@@ -124,8 +138,13 @@ Subscriptions update are not immediatly applied. openwec server maintains an in-
 $ openwec subscriptions edit my-super-subscription --uri /new-uri --connection-retry-count 10
 ```
 
-This commad edits the subscription named `my-super-subscription`, changing its uri to `/new-uri` and its `connection_retry_count` parameter to `10`.
+This command edits the subscription named `my-super-subscription`, changing its uri to `/new-uri` and its `connection_retry_count` parameter to `10`.
 
+```
+$ openwec subscriptions edit my-super-subscription filter set only 'SUSPICIOUS$@WINDOMAIN.LOCAL' 'INFECTED$@WINDOMAIN.LOCAL'
+```
+
+This command edits the subscription named `my-super-subscription`, changing its filter to _only_ retrieve events from `SUSPICIOUS$@WINDOMAIN.LOCAL` and `INFECTED$@WINDOMAIN.LOCAL`.
 
 ### `openwec subscriptions show`
 
@@ -147,7 +166,8 @@ Subscription my-super-subscription
 	ReadExistingEvents: false
 	ContentFormat: Raw
 	IgnoreChannelError: true
-	Outputs: None
+	Principal filter: Not configured
+	Outputs: Not configured 
 	Enabled: false
 
 Event filter query:
@@ -190,6 +210,7 @@ Subscription this-is-a-clone
 	ReadExistingEvents: false
 	ContentFormat: Raw
 	IgnoreChannelError: true
+	Principal filter: Not configured
 	Outputs: None
 	Enabled: false
 
@@ -218,7 +239,7 @@ These subscriptions can be imported in another openwec installation.
 
 ```
 $ openwec subscriptions export
-[{"uuid":"27D8CE0B-CAFE-44CA-9FE1-4B9D6EE45AE8","version":"3366A5BD-9E71-482E-9359-9505EA1F8400","name":"my-super-subscription","uri":"/new-uri","query":"<QueryList>\n    <Query Id=\"0\" Path=\"Application\">\n        <Select Path=\"Application\">*</Select>\n        <Select Path=\"Security\">*</Select>\n        <Select Path=\"Setup\">*</Select>\n        <Select Path=\"System\">*</Select>\n    </Query>\n</QueryList>\n","heartbeat_interval":600,"connection_retry_count":10,"connection_retry_interval":60,"max_time":600,"max_envelope_size":512000,"enabled":false,"read_existing_events":false,"content_format":"Raw","ignore_channel_error":true,"outputs":[]},[...]]
+[{"uuid":"27D8CE0B-CAFE-44CA-9FE1-4B9D6EE45AE8","version":"3366A5BD-9E71-482E-9359-9505EA1F8400","name":"my-super-subscription","uri":"/new-uri","query":"<QueryList>\n    <Query Id=\"0\" Path=\"Application\">\n        <Select Path=\"Application\">*</Select>\n        <Select Path=\"Security\">*</Select>\n        <Select Path=\"Setup\">*</Select>\n        <Select Path=\"System\">*</Select>\n    </Query>\n</QueryList>\n","heartbeat_interval":600,"connection_retry_count":10,"connection_retry_interval":60,"max_time":600,"max_envelope_size":512000,"enabled":false,"read_existing_events":false,"content_format":"Raw","ignore_channel_error":true,"princs_filter":{"operation":null,"princs":[]},"outputs":[]},[...]]
 ```
 
 ### `openwec subscriptions import`


### PR DESCRIPTION
The principals filter allows you to filter whether a machine (identified by its Kerberos principal name) can see a subscription.

There are 3 filtering modes :
* None (default): no filtering
* Only : allow only the specified principals to see the subscription
* Except : allow anyone to see the subscription except the specified principals

The comparison of principal names is case-sensitive.