### PR TITLE
Multiple fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make ContentFormat of subscriptions configurable (#1)
 - Add IgnoreChannelError option to subscriptions (#6)
 - Add Kerberos principals filter to subscriptions (#18)
+- Add a setting to configure `heartbeats_queue_size` (#37)
+
+### Changed
+
+
+- Server log responses payload in TRACE level (#37)
+- Remove `OperationID` from responses because we don't support "Robust Connection" (#37)
+- Clear in-memory subscriptions when a SIGHUP signal is received, resulting in all file descriptors used by subscriptions being closed (#37)
+- `heartbeats_queue_size` now defauts to 2048 instead of 32 (#37)
 
 ## [0.1.0] - 2023-05-30
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
     "common",

--- a/common/src/settings.rs
+++ b/common/src/settings.rs
@@ -184,6 +184,7 @@ pub struct Server {
     verbosity: Option<String>,
     db_sync_interval: Option<u64>,
     flush_heartbeats_interval: Option<u64>,
+    heartbeats_queue_size: Option<u64>,
     node_name: Option<String>,
 }
 
@@ -202,6 +203,10 @@ impl Server {
 
     pub fn node_name(&self) -> Option<&String> {
         self.node_name.as_ref()
+    }
+
+    pub fn heartbeats_queue_size(&self) -> u64 {
+        self.heartbeats_queue_size.unwrap_or(2048)
     }
 }
 

--- a/openwec.conf.sample.toml
+++ b/openwec.conf.sample.toml
@@ -30,6 +30,17 @@
 # flush_heartbeats_interval = 5
 
 # [Optional]
+# To "store" a heartbeat, request handlers send a message to a task responsible
+# for managing heartbeats using a queue.
+# The database store operation may take some time. During this operation, new heartbeats message
+# are not popped from the queue, leading to the queue being full. When the queue is full,
+# request handlers have to wait before sending a response to clients.
+# You can customize the size of the queue, depending of the expected output of heartbeats
+# messages to store and the duration of the database store operation.
+# Default size of the queue is 2048.
+# heartbeats_queue_size = 2048
+
+# [Optional]
 # Set node name
 # This may be used by outputs. Unset by default.
 # node_name = unsef

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -347,6 +347,12 @@ async fn handle(
         }
     };
 
+    trace!(
+        "Send response {} with payload: {:?}",
+        status,
+        response_payload
+    );
+
     response_builder = response_builder.status(status);
     // Create HTTP response
     let response = match create_response(auth_mech, &conn_state, response_builder, response_payload)

--- a/server/src/soap.rs
+++ b/server/src/soap.rs
@@ -551,7 +551,7 @@ impl Message {
                 max_envelope_size: None,
                 message_id: Some(new_uuid()),
                 session_id: None,
-                operation_id: message.header.operation_id.clone(),
+                operation_id: None,
                 sequence_id: Some(1),
                 relates_to: Some(
                     message


### PR DESCRIPTION
- server: log response payload in TRACE level.
- server: remove `OperationID` from OpenWEC responses because we don't support "Robust Connection" (MS-WSMV 3.1.4.1.39).
- server: clear in-memory subscriptions when a SIGHUP signal is received, resulting in all file descriptors used by subscriptions being closed. This is required for log rotating programs.
- server: make the heartbeat_queue_size configurable.