### PR TITLE
Keytab setting is bound to server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove `OperationID` from responses because we don't support "Robust Connection" (#37)
 - Clear in-memory subscriptions when a SIGHUP signal is received, resulting in all file descriptors used by subscriptions being closed (#37)
 - `heartbeats_queue_size` now defaults to 2048 instead of 32 (#37)
+- **Breaking change**: Keytab file path must be specified only once for all collectors (using Kerberos authentication)
 
 ## [0.1.0] - 2023-05-30
 

--- a/common/src/settings.rs
+++ b/common/src/settings.rs
@@ -73,16 +73,17 @@ impl Collector {
 #[derive(Debug, Deserialize, Clone)]
 pub struct Kerberos {
     service_principal_name: String,
-    keytab: String,
 }
 
 impl Kerberos {
-    pub fn service_principal_name(&self) -> &str {
-        &self.service_principal_name
+    pub fn empty() -> Self {
+        Kerberos {
+            service_principal_name: String::new(),
+        }
     }
 
-    pub fn keytab(&self) -> &str {
-        &self.keytab
+    pub fn service_principal_name(&self) -> &str {
+        &self.service_principal_name
     }
 }
 
@@ -186,6 +187,7 @@ pub struct Server {
     flush_heartbeats_interval: Option<u64>,
     heartbeats_queue_size: Option<u64>,
     node_name: Option<String>,
+    keytab: Option<String>,
 }
 
 impl Server {
@@ -207,6 +209,10 @@ impl Server {
 
     pub fn heartbeats_queue_size(&self) -> u64 {
         self.heartbeats_queue_size.unwrap_or(2048)
+    }
+
+    pub fn keytab(&self) -> Option<&String> {
+        self.keytab.as_ref()
     }
 }
 
@@ -253,6 +259,7 @@ mod tests {
     const CONFIG_KERBEROS_SQLITE: &str = r#"
         [server]
         verbosity = "debug"
+        keytab = "wec.windomain.local.keytab"
 
         [database]
         type =  "SQLite"
@@ -267,7 +274,6 @@ mod tests {
         [collectors.authentication]
         type = "Kerberos"
         service_principal_name = "http/wec.windomain.local@WINDOMAIN.LOCAL"
-        keytab = "wec.windomain.local.keytab"
     "#;
 
     #[test]
@@ -284,7 +290,7 @@ mod tests {
             Authentication::Kerberos(kerb) => kerb,
             _ => panic!("Wrong authentication type"),
         };
-        assert_eq!(kerberos.keytab(), "wec.windomain.local.keytab");
+        assert_eq!(s.server().keytab().unwrap(), "wec.windomain.local.keytab");
         assert_eq!(
             kerberos.service_principal_name(),
             "http/wec.windomain.local@WINDOMAIN.LOCAL"

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -34,9 +34,7 @@ Write the following content in `/etc/openwec.conf.toml`:
 ```toml
 # /etc/openwec.conf.toml
 [server]
-verbosity = "info"
-db_sync_interval = 5
-flush_heartbeats_interval = 5
+keytab = "/etc/wec.windomain.local.keytab"
 
 [database]
 type = "SQLite"
@@ -50,7 +48,6 @@ listen_address = "0.0.0.0"
 [collectors.authentication]
 type = "Kerberos"
 service_principal_name = "http/wec.windomain.local@WINDOMAIN.LOCAL"
-keytab = "/etc/wec.windomain.local.keytab"
 ```
 
 See [openwec.conf.sample.toml](../openwec.conf.sample.toml) for further information on available parameters.

--- a/openwec.conf.sample.toml
+++ b/openwec.conf.sample.toml
@@ -45,6 +45,13 @@
 # This may be used by outputs. Unset by default.
 # node_name = unsef
 
+# [Optional]
+# Keytab file path that contains secrets for Kerberos SPNs used by collectors.
+# Required if Kerberos authentication is used by at least one collector.
+# It must contain entries for service principals used by collectors.
+# It can contain other entries that aren't used by openwec.
+# keytab = "/etc/krb5.keytab"
+
 ##########################
 ##  Databases settings  ##
 ##########################
@@ -148,16 +155,12 @@
 
 ## Kerberos configuration
 
+# [server.keytab] is required when using Kerberos authentication
+
 # [Required]
 # Service Principal Name of the openwec account
 # Should be something like "HTTP/openwec.mydomain.local@MYDOMAIN.LOCAL"
 # service_principal_name = ""
-
-# [Required]
-# Keytab file that contains secrets of the openwec account.
-# It must contain an entry for the principal <kerberos.service_principal_name>.
-# It may contains other entries, which won't be used by openwec.
-# keytab = "/etc/krb5.keytab"
 
 ## End of Kerberos configuration
 


### PR DESCRIPTION
Previously, it was possible to configure multiple collectors, each using a different keytab. However, this didn't work because the keytab to use is set as an environment variable (`KRB5_KTNAME`) for libgssapi.

A keytab file can contain many secrets (even for different accounts), so supporting multiple keytabs is not really useful (and would require a patch in the safe Rust wrapper for libgssapi). Therefore, I propose to remove the ability to configure a keytab per collector, and instead bind the keytab setting to `server'.