### PR TITLE
Formatters can not fail when formatting an event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clear in-memory subscriptions when a SIGHUP signal is received, resulting in all file descriptors used by subscriptions being closed (#37)
 - `heartbeats_queue_size` now defaults to 2048 instead of 32 (#37)
 - **Breaking change**: Keytab file path must be specified only once for all collectors (using Kerberos authentication)
+- A malformed event will no longer stop the event stream (for a computer/subscription) because formatters are not allowed to fail. In problematic cases, some work is done to try to recover the raw data of the event, and an `OpenWEC.Error` field is added (in the JSON formatter) to help catch the problem (#47)
 
 ## [0.1.0] - 2023-05-30
 

--- a/doc/formats.md
+++ b/doc/formats.md
@@ -44,6 +44,12 @@ openwec_data := {
         "Version": string,
         "Uuid": string,
         "Uri": string
+    },
+    /* Only in case of error during event parsing or serializing */
+    "Error": {
+        "OriginalContent": string,
+        "Type": string,
+        "Message": string
     }
 }
 

--- a/server/src/logic.rs
+++ b/server/src/logic.rs
@@ -356,11 +356,9 @@ async fn handle_events(
         for format in subscription.formats() {
             let mut content = Vec::new();
             for raw in events.iter() {
-                content.push(
-                    format
-                        .format(&metadata, raw.clone())
-                        .with_context(|| format!("Failed to format event with {:?}", format))?,
-                );
+                if let Some(str) = format.format(&metadata, raw.clone()) {
+                    content.push(str.clone())
+                }
             }
             formatted_events.insert(format.clone(), Arc::new(content));
         }


### PR DESCRIPTION
In the case of a malformed event, multiple recovery strategies are attempted and an error message is added to the formatted message.

See #46 