### PR TITLE
Various fixes

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -29,6 +29,8 @@ jobs:
         sh up.sh
     - name: Build
       run: cargo build --verbose
+    - name: Clippy
+      run: cargo clippy
     - name: Run tests
       run: |
         # Env var to connect to the Postgres docker

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Clippy
-      run: cargo clippy
+      run: cargo clippy -- -Dwarnings
     - name: Run tests
       run: |
         # Env var to connect to the Postgres docker

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1917,6 +1917,7 @@ dependencies = [
  "tls-listener",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "uuid",
  "x509-parser",
  "xmlparser",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::too_many_arguments)]
+
 use std::env;
 
 use common::{database::schema::Version, settings::DEFAULT_CONFIG_FILE};

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -10,10 +10,9 @@ pub fn confirm(message: &str) -> bool {
         print!("{} [y/n] ", message);
         io::stdout().flush().unwrap();
         let mut input = String::new();
-        match io::stdin().read_line(&mut input) {
-            Ok(2) => return input.to_ascii_lowercase().trim() == "y",
-            _ => (),
-        };
+        if let Ok(2) = io::stdin().read_line(&mut input) {
+            return input.to_ascii_lowercase().trim() == "y";
+        }
     }
     false
 }

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -11,7 +11,7 @@ pub fn confirm(message: &str) -> bool {
         io::stdout().flush().unwrap();
         let mut input = String::new();
         match io::stdin().read_line(&mut input) {
-            Ok(n) if n == 2 => return input.to_ascii_lowercase().trim() == "y",
+            Ok(2) => return input.to_ascii_lowercase().trim() == "y",
             _ => (),
         };
     }

--- a/common/src/database/postgres.rs
+++ b/common/src/database/postgres.rs
@@ -90,12 +90,14 @@ pub struct PostgresDatabase {
 
 impl PostgresDatabase {
     pub async fn new(settings: &Postgres) -> Result<PostgresDatabase> {
-        let mut config = Config::default();
-        config.host = Some(settings.host().to_string());
-        config.port = Some(settings.port());
-        config.user = Some(settings.user().to_string());
-        config.password = Some(settings.password().to_string());
-        config.dbname = Some(settings.dbname().to_string());
+        let mut config = Config {
+            host: Some(settings.host().to_string()),
+            port: Some(settings.port()),
+            user: Some(settings.user().to_string()),
+            password: Some(settings.password().to_string()),
+            dbname: Some(settings.dbname().to_string()),
+            ..Default::default()
+        };
 
         let pool = if *settings.ssl_mode() == PostgresSslMode::Disable {
             config

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::too_many_arguments)]
+
 pub mod bookmark;
 pub mod database;
 pub mod encoding;

--- a/common/src/settings.rs
+++ b/common/src/settings.rs
@@ -98,17 +98,12 @@ impl SQLite {
     }
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq, Default)]
 pub enum PostgresSslMode {
     Disable,
+    #[default]
     Prefer,
     Require,
-}
-
-impl Default for PostgresSslMode {
-    fn default() -> Self {
-        PostgresSslMode::Prefer
-    }
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -48,3 +48,4 @@ hex = "0.4.3"
 redis = { version = "0.23.3", features = ["tokio-comp", "aio"]}
 log4rs = "1.2.0"
 log-mdc = "0.1.0"
+tokio-util = "0.7.10"

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::too_many_arguments)]
+
 mod event;
 mod formatter;
 mod heartbeat;

--- a/server/src/logic.rs
+++ b/server/src/logic.rs
@@ -15,7 +15,7 @@ use common::{
     settings::{Collector, Server},
 };
 use http::status::StatusCode;
-use log::{debug, error, info, warn};
+use log::{debug, error, warn};
 use std::{collections::HashMap, sync::Arc};
 use tokio::{sync::mpsc, task::JoinSet};
 
@@ -70,7 +70,7 @@ async fn handle_enumerate(
         }
     };
 
-    info!(
+    debug!(
         "Received Enumerate request from {}:{} ({}) with URI {}",
         request_data.remote_addr.ip(),
         request_data.remote_addr.port(),
@@ -261,7 +261,7 @@ async fn handle_heartbeat(
     };
 
     if !subscription.data().is_active_for(request_data.principal()) {
-        info!(
+        debug!(
             "Received Heartbeat from {}:{} ({}) for subscription {} ({}) but the principal is not allowed to use the subscription.",
             request_data.remote_addr().ip(),
             request_data.remote_addr().port(),
@@ -272,7 +272,7 @@ async fn handle_heartbeat(
         return Ok(Response::err(StatusCode::FORBIDDEN));
     }
 
-    info!(
+    debug!(
         "Received Heartbeat from {}:{} ({:?}) for subscription {} ({})",
         request_data.remote_addr().ip(),
         request_data.remote_addr().port(),
@@ -324,7 +324,7 @@ async fn handle_events(
         };
 
         if !subscription.data().is_active_for(request_data.principal()) {
-            info!(
+            debug!(
                 "Received Events from {}:{} ({}) for subscription {} ({}) but the principal is not allowed to use this subscription.",
                 request_data.remote_addr().ip(),
                 request_data.remote_addr().port(),
@@ -335,7 +335,7 @@ async fn handle_events(
             return Ok(Response::err(StatusCode::FORBIDDEN));
         }
 
-        info!(
+        debug!(
             "Received Events from {}:{} ({}) for subscription {} ({})",
             request_data.remote_addr().ip(),
             request_data.remote_addr().port(),


### PR DESCRIPTION
* Rework task graceful shutdown using `tokio_util::CancellationToken` instead of `mpsc::channel`
* Fix clippy warnings (and ignore [too_many_arguments](https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments)).
* Update some log levels from `INFO` to `DEBUG` so that the `INFO` log level can actually be used in production
* Add a `cargo clippy` check in GitHub CI