### PR TITLE
Fixes & improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A malformed event will no longer stop the event stream (for a computer/subscription) because formatters are not allowed to fail. In problematic cases, some work is done to try to recover the raw data of the event, and an `OpenWEC.Error` field is added (in the JSON formatter) to help catch the problem (#47)
 - **Breaking change**: Split access and server logs. Configuration file format has been updated. (#52)
 - Ensure that openwecd shutdowns gracefully even if hyper server is not responding
+- Improve the logging of failed Kerberos authentications: missing authorization header warning is now in DEBUG level
 
 ## [0.1.0] - 2023-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure that openwecd shutdowns gracefully even if hyper server is not responding
 - Improve the logging of failed Kerberos authentications: missing authorization header warning is now in DEBUG level
 
+### Fixed
+
+- Fixed an issue that could result in an inconsistent state when a client unexpectedly closes an HTTP connection.
+
 ## [0.1.0] - 2023-05-30
 
 Initial commit containing most of the desired features. The project is still under heavy development and production use without a backup solution should be avoided.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-##  [Unreleased]
+## [Unreleased]
 
 ### Added
 
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking change**: Keytab file path must be specified only once for all collectors (using Kerberos authentication)
 - A malformed event will no longer stop the event stream (for a computer/subscription) because formatters are not allowed to fail. In problematic cases, some work is done to try to recover the raw data of the event, and an `OpenWEC.Error` field is added (in the JSON formatter) to help catch the problem (#47)
 - **Breaking change**: Split access and server logs. Configuration file format has been updated. (#52)
+- Ensure that openwecd shutdowns gracefully even if hyper server is not responding
 
 ## [0.1.0] - 2023-05-30
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1914,6 +1914,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
+ "thiserror",
  "tls-listener",
  "tokio",
  "tokio-rustls",

--- a/openwec.conf.sample.toml
+++ b/openwec.conf.sample.toml
@@ -110,6 +110,8 @@
 # - ip
 # - port
 # - principal
+# - conn_status: 'X' (connection aborted before the response completed)
+#                '+' (connection may be kept alive after the response is sent)
 # Default value is None, meaning "{X(ip)}:{X(port)} - {X(principal)} [{d}] \"{X(http_uri)}\" {X(http_status)} {X(response_time)}{n}"
 # access_logs_pattern = None
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -49,3 +49,4 @@ redis = { version = "0.23.3", features = ["tokio-comp", "aio"]}
 log4rs = "1.2.0"
 log-mdc = "0.1.0"
 tokio-util = "0.7.10"
+thiserror = "1.0.50"

--- a/server/src/logic.rs
+++ b/server/src/logic.rs
@@ -441,7 +441,7 @@ pub async fn handle_message(
     db: Db,
     subscriptions: Subscriptions,
     heartbeat_tx: mpsc::Sender<WriteHeartbeatMessage>,
-    request_data: RequestData,
+    request_data: &RequestData,
     message: &Message,
     auth_ctx: &AuthenticationContext,
 ) -> Result<Response> {
@@ -449,13 +449,13 @@ pub async fn handle_message(
     debug!("Received {} request", action);
 
     if action == ACTION_ENUMERATE {
-        handle_enumerate(collector, &db, subscriptions, &request_data, auth_ctx)
+        handle_enumerate(collector, &db, subscriptions, request_data, auth_ctx)
             .await
             .context("Failed to handle Enumerate action")
     } else if action == ACTION_END || action == ACTION_SUBSCRIPTION_END {
         Ok(Response::err(StatusCode::OK))
     } else if action == ACTION_HEARTBEAT {
-        handle_heartbeat(subscriptions, heartbeat_tx, &request_data, message)
+        handle_heartbeat(subscriptions, heartbeat_tx, request_data, message)
             .await
             .context("Failed to handle Heartbeat action")
     } else if action == ACTION_EVENTS {
@@ -464,7 +464,7 @@ pub async fn handle_message(
             &db,
             subscriptions,
             heartbeat_tx,
-            &request_data,
+            request_data,
             message,
         )
         .await

--- a/server/src/outputs/file.rs
+++ b/server/src/outputs/file.rs
@@ -25,7 +25,7 @@ pub struct WriteFileMessage {
 
 async fn handle_message(
     file_handles: &mut HashMap<PathBuf, File>,
-    message: &mut WriteFileMessage,
+    message: &WriteFileMessage,
 ) -> Result<()> {
     let parent = message
         .path
@@ -67,8 +67,8 @@ pub async fn run(mut task_rx: mpsc::Receiver<WriteFileMessage>, task_ct: Cancell
     let mut file_handles: HashMap<PathBuf, File> = HashMap::new();
     loop {
         tokio::select! {
-            Some(mut message) = task_rx.recv() => {
-                let result = handle_message(&mut file_handles, &mut message).await;
+            Some(message) = task_rx.recv() => {
+                let result = handle_message(&mut file_handles, &message).await;
                 if let Err(e) = message
                     .resp
                     .send(result) {


### PR DESCRIPTION
- Ensure that openwecd shutdowns gracefully even if hyper server is not responding (using a 10 seconds timeout)
- Improve the logging of failed Kerberos authentications: missing authorization header warning is now in DEBUG level. Other errors remain in WARN. The idea behind this change is to make the INFO log level usable in production.
- Fixed an issue that could result in an inconsistent state when a client unexpectedly closes an HTTP connection (read the added comments in `server/src/lib.rs:handle`)