### PR TITLE
make openssl output munging more robust

### DIFF
--- a/doc/tls.md
+++ b/doc/tls.md
@@ -68,7 +68,7 @@ openssl req -x509 -nodes -key ca-key.pem -out ca-cert.pem -batch -subj "$SUBJ" -
 
 # Server certificate
 SERVERNAME="$2"
-ISSUERCA=`openssl x509 -in ca-cert.pem -noout -sha1 -fingerprint |sed s/^SHA1\ Fingerprint=//|sed s/://g`
+ISSUERCA=`openssl x509 -in ca-cert.pem -noout -sha1 -fingerprint |sed s/^SHA1\ Fingerprint=//i|sed s/://g`
 SERVERSUBJ="/CN=$SERVERNAME/O=example.local/C=HU/ST=state/L=location"
 CERTDIR=.
 openssl ecparam -out server-key.pem -name $CURVE -genkey


### PR DESCRIPTION
Apparently current `openssl` versions (in this case Debian stable's `OpenSSL 3.0.11 19 Sep 2023 (Library: OpenSSL 3.0.11 19 Sep 2023)`) output a string that the WEF cert generation script expect to be in uppercase in lowercase:
```
$ openssl x509 -in ca-cert.pem -noout -sha1 -fingerprint
sha1 Fingerprint=F5:92:6F:9D:FC:2D:B7:45:CE:76:CA:3F:E9:2F:7C:48:15:C0:42:29
```
which would lead to an invalid subscription manager string like:
```
Server=HTTPS://server:5985/wsman/,Refresh=14400,IssuerCA=sha1 Fingerprint=F5926F9DFC2DB745CE76CA3FE92F7C4815C04229

```
to be generated instead of the correct:
```
Server=HTTPS://server:5985/wsman/,Refresh=14400,IssuerCA=F5926F9DFC2DB745CE76CA3FE92F7C4815C04229
```

This fix makes the `sed` operation case-independent to ensure that this is not a breaking issue. There is also a corresponding MR here: https://gitlab.com/nxlog-public/contrib/-/merge_requests/27