### PR TITLE
Optionally expose usage metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `max_elements` subscription parameter (#185)
+- Add an optional Prometheus endpoint that exposes metrics (#190)
 
 ## [v0.3.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,6 +462,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +485,21 @@ checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crypto-common"
@@ -706,6 +731,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,12 +920,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1007,6 +1047,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1061,13 +1119,19 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.0",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1286,6 +1350,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "metrics"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae428771d17306715c5091d446327d1cfdedc82185c65ba8423ab404e45bf10"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b6f8152da6d7892ff1b7a1c0fa3f435e92b5918ad67035c3bb432111d9a29b"
+dependencies = [
+ "base64 0.22.1",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "indexmap",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b482df36c13dd1869d73d14d28cd4855fbd6cfc32294bee109908a9f4a4ed7"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.0",
+ "metrics",
+ "quanta",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "miette"
 version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1473,6 +1582,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1585,6 +1700,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
+name = "portable-atomic"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+
+[[package]]
 name = "postgres-openssl"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1677,6 +1798,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1722,6 +1858,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ab240315c661615f2ee9f0f2cd32d5a7343a84d5ebcccb99d46e6637565e7b0"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -1915,6 +2060,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1964,6 +2122,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1974,6 +2141,29 @@ name = "sdd"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b84345e4c9bd703274a082fb80caaa99b7612be48dfaa1dd9266577ec412309d"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -2089,6 +2279,8 @@ dependencies = [
  "log",
  "log-mdc",
  "log4rs",
+ "metrics",
+ "metrics-exporter-prometheus",
  "mime",
  "ppp",
  "quick-xml",
@@ -2159,6 +2351,12 @@ name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
 
 [[package]]
 name = "slab"

--- a/common/src/settings.rs
+++ b/common/src/settings.rs
@@ -374,8 +374,8 @@ pub struct Monitoring {
     listen_address: String,
     listen_port: u16,
     http_request_duration_buckets: Option<Vec<f64>>,
-    count_received_events_per_machine: Option<bool>,
-    count_event_size_per_machine: Option<bool>,
+    count_input_events_per_machine: Option<bool>,
+    count_input_event_bytes_per_machine: Option<bool>,
     count_http_request_body_network_size_per_machine: Option<bool>,
     count_http_request_body_real_size_per_machine: Option<bool>,
 }
@@ -398,12 +398,12 @@ impl Monitoring {
         }
     }
 
-    pub fn count_received_events_per_machine(&self) -> bool {
-        self.count_received_events_per_machine.unwrap_or(false)
+    pub fn count_input_events_per_machine(&self) -> bool {
+        self.count_input_events_per_machine.unwrap_or(false)
     }
 
-    pub fn count_event_size_per_machine(&self) -> bool {
-        self.count_event_size_per_machine.unwrap_or(false)
+    pub fn count_input_event_bytes_per_machine(&self) -> bool {
+        self.count_input_event_bytes_per_machine.unwrap_or(false)
     }
 
     pub fn count_http_request_body_network_size_per_machine(&self) -> bool {
@@ -632,7 +632,9 @@ mod tests {
         assert_eq!(s.monitoring().unwrap().listen_address(), "127.0.0.1");
         assert_eq!(s.monitoring().unwrap().listen_port(), 9090);
         assert_eq!(
-            s.monitoring().unwrap().count_event_size_per_machine(),
+            s.monitoring()
+                .unwrap()
+                .count_input_event_bytes_per_machine(),
             false
         );
         assert_eq!(
@@ -648,7 +650,7 @@ mod tests {
             false
         );
         assert_eq!(
-            s.monitoring().unwrap().count_received_events_per_machine(),
+            s.monitoring().unwrap().count_input_events_per_machine(),
             false
         );
         assert_eq!(
@@ -688,10 +690,10 @@ mod tests {
         listen_address = "127.0.0.1"
         listen_port = 9090
         http_request_duration_buckets = [0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0]
-        count_event_size_per_machine = true
+        count_input_event_bytes_per_machine = true
         count_http_request_body_network_size_per_machine = true
         count_http_request_body_real_size_per_machine = true
-        count_received_events_per_machine = true
+        count_input_events_per_machine = true
     "#;
 
     #[test]
@@ -702,7 +704,12 @@ mod tests {
         assert!(s.monitoring().is_some());
         assert_eq!(s.monitoring().unwrap().listen_address(), "127.0.0.1");
         assert_eq!(s.monitoring().unwrap().listen_port(), 9090);
-        assert_eq!(s.monitoring().unwrap().count_event_size_per_machine(), true);
+        assert_eq!(
+            s.monitoring()
+                .unwrap()
+                .count_input_event_bytes_per_machine(),
+            true
+        );
         assert_eq!(
             s.monitoring()
                 .unwrap()
@@ -716,7 +723,7 @@ mod tests {
             true
         );
         assert_eq!(
-            s.monitoring().unwrap().count_received_events_per_machine(),
+            s.monitoring().unwrap().count_input_events_per_machine(),
             true
         );
         assert_eq!(

--- a/common/src/settings.rs
+++ b/common/src/settings.rs
@@ -322,7 +322,7 @@ impl Cli {
 #[serde(deny_unknown_fields)]
 pub struct FilesOutput {
     // Time after which an unused file descriptor is closed
-    files_descriptor_close_timeout: Option<u64>
+    files_descriptor_close_timeout: Option<u64>,
 }
 
 impl FilesOutput {
@@ -351,7 +351,7 @@ pub struct Outputs {
     #[serde(default)]
     files: FilesOutput,
     #[serde(default)]
-    kafka: KafkaOutput
+    kafka: KafkaOutput,
 }
 
 impl Outputs {
@@ -368,6 +368,33 @@ impl Outputs {
     }
 }
 
+#[derive(Debug, Deserialize, Clone, Default)]
+#[serde(deny_unknown_fields)]
+pub struct Monitoring {
+    listen_address: String,
+    listen_port: u16,
+    http_requests_histogram_buckets: Option<Vec<f64>>,
+}
+
+impl Monitoring {
+    pub fn listen_address(&self) -> &str {
+        &self.listen_address
+    }
+
+    pub fn listen_port(&self) -> u16 {
+        self.listen_port
+    }
+
+    pub fn http_requests_histogram_buckets(&self) -> &[f64] {
+        match &self.http_requests_histogram_buckets {
+            Some(bucket) => bucket,
+            None => &[
+                0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+            ],
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct Settings {
@@ -381,6 +408,8 @@ pub struct Settings {
     cli: Cli,
     #[serde(default)]
     outputs: Outputs,
+    #[serde(default)]
+    monitoring: Option<Monitoring>,
 }
 
 impl std::str::FromStr for Settings {
@@ -421,6 +450,10 @@ impl Settings {
 
     pub fn outputs(&self) -> &Outputs {
         &self.outputs
+    }
+
+    pub fn monitoring(&self) -> Option<&Monitoring> {
+        self.monitoring.as_ref()
     }
 }
 

--- a/common/src/settings.rs
+++ b/common/src/settings.rs
@@ -373,7 +373,7 @@ impl Outputs {
 pub struct Monitoring {
     listen_address: String,
     listen_port: u16,
-    http_requests_histogram_buckets: Option<Vec<f64>>,
+    http_request_duration_buckets: Option<Vec<f64>>,
     count_received_events_per_machine: Option<bool>,
     count_event_size_per_machine: Option<bool>,
     count_http_request_body_network_size_per_machine: Option<bool>,
@@ -389,8 +389,8 @@ impl Monitoring {
         self.listen_port
     }
 
-    pub fn http_requests_histogram_buckets(&self) -> &[f64] {
-        match &self.http_requests_histogram_buckets {
+    pub fn http_request_duration_buckets(&self) -> &[f64] {
+        match &self.http_request_duration_buckets {
             Some(bucket) => bucket,
             None => &[
                 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
@@ -651,6 +651,10 @@ mod tests {
             s.monitoring().unwrap().count_received_events_per_machine(),
             false
         );
+        assert_eq!(
+            s.monitoring().unwrap().http_request_duration_buckets(),
+            &[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,]
+        );
     }
 
     const CONFIG_TLS_POSTGRES_WITH_CLI: &str = r#"
@@ -683,6 +687,7 @@ mod tests {
         [monitoring]
         listen_address = "127.0.0.1"
         listen_port = 9090
+        http_request_duration_buckets = [0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0]
         count_event_size_per_machine = true
         count_http_request_body_network_size_per_machine = true
         count_http_request_body_real_size_per_machine = true
@@ -713,6 +718,10 @@ mod tests {
         assert_eq!(
             s.monitoring().unwrap().count_received_events_per_machine(),
             true
+        );
+        assert_eq!(
+            s.monitoring().unwrap().http_request_duration_buckets(),
+            &[0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0]
         );
     }
 

--- a/common/src/settings.rs
+++ b/common/src/settings.rs
@@ -375,6 +375,9 @@ pub struct Monitoring {
     listen_port: u16,
     http_requests_histogram_buckets: Option<Vec<f64>>,
     count_received_events_per_machine: Option<bool>,
+    count_event_size_per_machine: Option<bool>,
+    count_http_request_body_network_size_per_machine: Option<bool>,
+    count_http_request_body_real_size_per_machine: Option<bool>,
 }
 
 impl Monitoring {
@@ -397,6 +400,20 @@ impl Monitoring {
 
     pub fn count_received_events_per_machine(&self) -> bool {
         self.count_received_events_per_machine.unwrap_or(false)
+    }
+
+    pub fn count_event_size_per_machine(&self) -> bool {
+        self.count_event_size_per_machine.unwrap_or(false)
+    }
+
+    pub fn count_http_request_body_network_size_per_machine(&self) -> bool {
+        self.count_http_request_body_network_size_per_machine
+            .unwrap_or(false)
+    }
+
+    pub fn count_http_request_body_real_size_per_machine(&self) -> bool {
+        self.count_http_request_body_real_size_per_machine
+            .unwrap_or(false)
     }
 }
 

--- a/common/src/settings.rs
+++ b/common/src/settings.rs
@@ -374,6 +374,7 @@ pub struct Monitoring {
     listen_address: String,
     listen_port: u16,
     http_requests_histogram_buckets: Option<Vec<f64>>,
+    count_received_events_per_machine: Option<bool>,
 }
 
 impl Monitoring {
@@ -392,6 +393,10 @@ impl Monitoring {
                 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
             ],
         }
+    }
+
+    pub fn count_received_events_per_machine(&self) -> bool {
+        self.count_received_events_per_machine.unwrap_or(false)
     }
 }
 

--- a/common/src/settings.rs
+++ b/common/src/settings.rs
@@ -378,6 +378,7 @@ pub struct Monitoring {
     count_input_event_bytes_per_machine: Option<bool>,
     count_http_request_body_network_size_per_machine: Option<bool>,
     count_http_request_body_real_size_per_machine: Option<bool>,
+    machines_refresh_interval: Option<u64>,
 }
 
 impl Monitoring {
@@ -414,6 +415,10 @@ impl Monitoring {
     pub fn count_http_request_body_real_size_per_machine(&self) -> bool {
         self.count_http_request_body_real_size_per_machine
             .unwrap_or(false)
+    }
+    
+    pub fn machines_refresh_interval(&self) -> u64 {
+        self.machines_refresh_interval.unwrap_or(30)
     }
 }
 
@@ -657,6 +662,9 @@ mod tests {
             s.monitoring().unwrap().http_request_duration_buckets(),
             &[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,]
         );
+        assert_eq!(
+            s.monitoring().unwrap().machines_refresh_interval(), 30
+        );
     }
 
     const CONFIG_TLS_POSTGRES_WITH_CLI: &str = r#"
@@ -694,6 +702,7 @@ mod tests {
         count_http_request_body_network_size_per_machine = true
         count_http_request_body_real_size_per_machine = true
         count_input_events_per_machine = true
+        machines_refresh_interval = 10
     "#;
 
     #[test]
@@ -729,6 +738,10 @@ mod tests {
         assert_eq!(
             s.monitoring().unwrap().http_request_duration_buckets(),
             &[0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0]
+        );
+        assert_eq!(
+            s.monitoring().unwrap().machines_refresh_interval(),
+            10
         );
     }
 

--- a/common/src/subscription.rs
+++ b/common/src/subscription.rs
@@ -913,6 +913,7 @@ impl SubscriptionStatsCounters {
     }
 }
 
+#[derive(IntoStaticStr)]
 pub enum SubscriptionMachineState {
     Alive,
     Active,

--- a/common/src/subscription.rs
+++ b/common/src/subscription.rs
@@ -8,7 +8,7 @@ use std::{
 use anyhow::{anyhow, bail, Result};
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
-use strum::{AsRefStr, EnumString, VariantNames};
+use strum::{AsRefStr, EnumString, IntoStaticStr, VariantNames};
 use uuid::Uuid;
 
 use crate::utils::VersionHasher;
@@ -96,12 +96,8 @@ pub struct FilesConfiguration {
 }
 
 impl FilesConfiguration {
-    pub fn new(
-        path: String,
-    ) -> Self {
-        Self {
-            path
-        }
+    pub fn new(path: String) -> Self {
+        Self { path }
     }
 
     pub fn path(&self) -> &str {
@@ -182,7 +178,17 @@ impl Display for SubscriptionOutput {
     }
 }
 #[derive(
-    Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Hash, VariantNames, AsRefStr, EnumString,
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Hash,
+    VariantNames,
+    AsRefStr,
+    EnumString,
+    IntoStaticStr,
 )]
 #[strum(serialize_all = "snake_case", ascii_case_insensitive)]
 pub enum SubscriptionOutputFormat {
@@ -683,8 +689,8 @@ impl SubscriptionData {
         self
     }
 
-     /// Set the subscription's max elements.
-     pub fn set_max_elements(&mut self, max_elements: Option<u32>) -> &mut Self {
+    /// Set the subscription's max elements.
+    pub fn set_max_elements(&mut self, max_elements: Option<u32>) -> &mut Self {
         self.parameters.max_elements = max_elements;
         self.update_internal_version();
         self

--- a/doc/monitoring.md
+++ b/doc/monitoring.md
@@ -28,3 +28,27 @@ $ openwec heartbeats -a 192.168.1.0 -s my-test-subscription
 ```
 
 Two formats are available: `text` (default) and `json` (`--format`).
+
+## Prometheus-compatible endpoint
+
+OpenWEC can expose a Prometheus-compatible endpoint with multiple metrics.
+
+### Configuration
+
+This feature is **disabled** by default.
+
+Metrics collection and publication can be enabled in the OpenWEC settings (see `monitoring` section of [openwec.conf.sample.toml](../openwec.conf.sample.toml)).
+
+### Available metrics
+
+| **Metric** | **Type** | **Labels** | **Description** |
+|---|---|---|---|
+| `openwec_received_events_total` | `Counter` | `subscription_uuid`, `subscription_name`, `machine` (optional*) | Number of events received by openwec |
+| `openwec_event_size_bytes_total` | `Counter` | `subscription_uuid`, `subscription_name`, `machine` (optional*) | The total size of all events received by openwec |
+| `http_request_body_real_size_bytes_total` | `Counter` | `method`, `uri`, `machine` (optional*) | The total size of all http requests body received by openwec after decryption and decompression |
+| `http_request_body_network_size_bytes_total` | `Counter` | `method`, `uri`, `machine` (optional*) | The total size of all http requests body received by openwec |
+| `openwec_messages_total` | `Counter` | `action` (one of `"enumerate"`, `"heartbeat"`, `"events"`) | Number of messages received by openwec |
+| `http_request_duration_seconds` | `Histogram` | `method`, `status`, `uri` | HTTP requests duration histogram |
+
+> [!WARNING]  
+> Enabling the `machine` labels may cause a **huge** increase in metric cardinality!

--- a/doc/monitoring.md
+++ b/doc/monitoring.md
@@ -43,13 +43,16 @@ Metrics collection and publication can be enabled in the OpenWEC settings (see `
 
 | **Metric** | **Type** | **Labels** | **Description** |
 |---|---|---|---|
-| `openwec_received_events_total` | `Counter` | `subscription_uuid`, `subscription_name`, `machine` (optional*) | Number of events received by openwec |
-| `openwec_event_size_bytes_total` | `Counter` | `subscription_uuid`, `subscription_name`, `machine` (optional*) | The total size of all events received by openwec |
-| `http_request_body_real_size_bytes_total` | `Counter` | `method`, `uri`, `machine` (optional*) | The total size of all http requests body received by openwec after decryption and decompression |
-| `http_request_body_network_size_bytes_total` | `Counter` | `method`, `uri`, `machine` (optional*) | The total size of all http requests body received by openwec |
-| `openwec_messages_total` | `Counter` | `action` (one of `"enumerate"`, `"heartbeat"`, `"events"`) | Number of messages received by openwec |
-| `openwec_event_output_failures_total` | `Counter` | `subscription_uuid`, `subscription_name` | Number of events that could not be written to outputs by openwec |
-| `http_request_duration_seconds` | `Histogram` | `method`, `status`, `uri` | HTTP requests duration histogram |
+| `openwec_input_events_total` | `Counter` | `subscription_uuid`, `subscription_name`, `machine` (optional*) | The total number of events received by openwec |
+| `openwec_input_event_bytes_total` | `Counter` | `subscription_uuid`, `subscription_name`, `machine` (optional*) | The total size of all events received by openwec |
+| `openwec_input_messages_total` | `Counter` | `action` (one of `"enumerate"`, `"heartbeat"`, `"events"`) | The total number of messages received by openwec |
+| `openwec_input_event_parsing_failures_total` | `Counter` | `subscription_uuid`, `subscription_name`, `type` | The total number of event parsing failures |
+| `openwec_http_requests_total` | `Counter` | `uri`, `code` | The total number of HTTP requests handled by openwec |
+| `openwec_http_request_duration_seconds` | `Histogram` | `uri` | Histogram of response duration for HTTP requests |
+| `openwec_http_request_body_network_size_bytes_total` | `Counter` | `uri`, `machine` (optional*) | The total size of all http requests body received by openwec |
+| `openwec_http_request_body_real_size_bytes_total` | `Counter` | `uri`, `machine` (optional*) | The total size of all http requests body received by openwec after decryption and decompression |
+| `openwec_output_driver_failures_total` | `Counter` | `subscription_uuid`, `subscription_name`, `driver` | The total number of output driver failures |
+| `openwec_output_format_failures_total` | `Counter` | `subscription_uuid`, `subscription_name`, `format` | The total number of output format failures |
 
 > [!WARNING]  
 > Enabling the `machine` labels may cause a **huge** increase in metric cardinality!

--- a/doc/monitoring.md
+++ b/doc/monitoring.md
@@ -48,6 +48,7 @@ Metrics collection and publication can be enabled in the OpenWEC settings (see `
 | `http_request_body_real_size_bytes_total` | `Counter` | `method`, `uri`, `machine` (optional*) | The total size of all http requests body received by openwec after decryption and decompression |
 | `http_request_body_network_size_bytes_total` | `Counter` | `method`, `uri`, `machine` (optional*) | The total size of all http requests body received by openwec |
 | `openwec_messages_total` | `Counter` | `action` (one of `"enumerate"`, `"heartbeat"`, `"events"`) | Number of messages received by openwec |
+| `openwec_event_output_failures_total` | `Counter` | `subscription_uuid`, `subscription_name` | Number of events that could not be written to outputs by openwec |
 | `http_request_duration_seconds` | `Histogram` | `method`, `status`, `uri` | HTTP requests duration histogram |
 
 > [!WARNING]  

--- a/doc/monitoring.md
+++ b/doc/monitoring.md
@@ -41,6 +41,9 @@ Metrics collection and publication can be enabled in the OpenWEC settings (see `
 
 ### Available metrics
 
+> [!CAUTION]  
+> Enabling the `machine` labels may cause a **huge** increase in metric cardinality! This is disabled by default.
+
 | **Metric** | **Type** | **Labels** | **Description** |
 |---|---|---|---|
 | `openwec_input_events_total` | `Counter` | `subscription_uuid`, `subscription_name`, `machine` (optional*) | The total number of events received by openwec |
@@ -53,6 +56,4 @@ Metrics collection and publication can be enabled in the OpenWEC settings (see `
 | `openwec_http_request_body_real_size_bytes_total` | `Counter` | `uri`, `machine` (optional*) | The total size of all http requests body received by openwec after decryption and decompression |
 | `openwec_output_driver_failures_total` | `Counter` | `subscription_uuid`, `subscription_name`, `driver` | The total number of output driver failures |
 | `openwec_output_format_failures_total` | `Counter` | `subscription_uuid`, `subscription_name`, `format` | The total number of output format failures |
-
-> [!WARNING]  
-> Enabling the `machine` labels may cause a **huge** increase in metric cardinality!
+| `openwec_machines` | `Gauge` | `subscription_uuid`, `subscription_name`, `state` | The number of machines known by openwec |

--- a/openwec.conf.sample.toml
+++ b/openwec.conf.sample.toml
@@ -322,6 +322,10 @@
 # listen_port =
 
 # [Optional]
+# Request duration buckets (in seconds) used by the "http_request_duration_seconds" histogram
+# http_request_duration_buckets = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]
+
+# [Optional]
 # If set, a "machine" label will be added to the "openwec_received_events_total" metric
 # Warning: this may cause a HUGE increase in metric cardinality
 # count_received_events_per_machine = false

--- a/openwec.conf.sample.toml
+++ b/openwec.conf.sample.toml
@@ -302,3 +302,41 @@
 # - If you configure Kafka options in an output, a dedicated Kafka client will be
 #     used for that output regardless of this setting.
 # options = {}
+
+##########################
+##  Monitoring settings ##
+##########################
+
+# OpenWEC can expose internal metrics on a Prometheus-compatible endpoint.
+# Monitoring is disabled by default.
+# You can enable it by uncommenting the [monitoring] section.
+
+# [monitoring]
+
+# [Required]
+# Listen address of the Prometheus-compatible endpoint
+# listen_address =
+
+# [Required]
+# Listen port of the Prometheus-compatible endpoint
+# listen_port =
+
+# [Optional]
+# If set, a "machine" label will be added to the "openwec_received_events_total" metric
+# Warning: this may cause a HUGE increase in metric cardinality
+# count_received_events_per_machine = false
+
+# [Optional]
+# If set, a "machine" label will be added to the "openwec_event_size_bytes_total" metric
+# Warning: this may cause a HUGE increase in metric cardinality
+# count_event_size_per_machine = false
+
+# [Optional]
+# If set, a "machine" label will be added to the "http_request_body_network_size_bytes_total" metric
+# Warning: this may cause a HUGE increase in metric cardinality
+# count_http_request_body_network_size_per_machine = false
+
+# [Optional]
+# If set, a "machine" label will be added to the "http_request_body_real_size_bytes_total" metric
+# Warning: this may cause a HUGE increase in metric cardinality
+# count_http_request_body_real_size_per_machine = false

--- a/openwec.conf.sample.toml
+++ b/openwec.conf.sample.toml
@@ -322,25 +322,25 @@
 # listen_port =
 
 # [Optional]
-# Request duration buckets (in seconds) used by the "http_request_duration_seconds" histogram
+# Request duration buckets (in seconds) used by the "openwec_http_request_duration_seconds" histogram
 # http_request_duration_buckets = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]
 
 # [Optional]
-# If set, a "machine" label will be added to the "openwec_received_events_total" metric
+# If set, a "machine" label will be added to the "openwec_input_events_total" metric
 # Warning: this may cause a HUGE increase in metric cardinality
-# count_received_events_per_machine = false
+# count_input_events_per_machine = false
 
 # [Optional]
-# If set, a "machine" label will be added to the "openwec_event_size_bytes_total" metric
+# If set, a "machine" label will be added to the "openwec_input_event_bytes_total" metric
 # Warning: this may cause a HUGE increase in metric cardinality
-# count_event_size_per_machine = false
+# count_input_event_bytes_per_machine = false
 
 # [Optional]
-# If set, a "machine" label will be added to the "http_request_body_network_size_bytes_total" metric
+# If set, a "machine" label will be added to the "openwec_http_request_body_network_size_bytes_total" metric
 # Warning: this may cause a HUGE increase in metric cardinality
 # count_http_request_body_network_size_per_machine = false
 
 # [Optional]
-# If set, a "machine" label will be added to the "http_request_body_real_size_bytes_total" metric
+# If set, a "machine" label will be added to the "openwec_http_request_body_real_size_bytes_total" metric
 # Warning: this may cause a HUGE increase in metric cardinality
 # count_http_request_body_real_size_per_machine = false

--- a/openwec.conf.sample.toml
+++ b/openwec.conf.sample.toml
@@ -322,6 +322,10 @@
 # listen_port =
 
 # [Optional]
+# The refresh interval of "openwec_machines" gauge
+# machines_refresh_interval = 30
+
+# [Optional]
 # Request duration buckets (in seconds) used by the "openwec_http_request_duration_seconds" histogram
 # http_request_duration_buckets = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -52,3 +52,5 @@ ppp = "2.2.0"
 tokio-rustls = "0.26.0"
 strum = { version = "0.26.1", features = ["derive"] }
 leon = "3.0.1"
+metrics = "0.24.0"
+metrics-exporter-prometheus = { version = "0.16.0", features = ["http-listener"] }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1112,10 +1112,6 @@ pub async fn run(settings: Settings, verbosity: u8) {
         panic!("Failed to setup logging: {:?}", e);
     }
 
-    if let Some(monitoring_settings) = settings.monitoring() {
-        monitoring::init(monitoring_settings).expect("Failed to set metric exporter");
-    }
-
     let rt_handle = Handle::current();
 
     // Start monitoring thread
@@ -1136,6 +1132,10 @@ pub async fn run(settings: Settings, verbosity: u8) {
     };
 
     let subscriptions = Arc::new(RwLock::new(HashMap::new()));
+
+    if let Some(monitoring_settings) = settings.monitoring() {
+        monitoring::init(&db, subscriptions.clone(), monitoring_settings).expect("Failed to initialize metrics exporter");
+    }
 
     let reload_interval = settings.server().db_sync_interval();
     let outputs_settings = settings.outputs().clone();

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -41,9 +41,9 @@ use libgssapi::error::MajorFlags;
 use log::{debug, error, info, trace, warn};
 use metrics::{counter, histogram};
 use monitoring::{
-    HTTP_REQUESTS_DURATION_SECONDS_HISTOGRAM, HTTP_REQUESTS_MACHINE, HTTP_REQUESTS_METHOD,
-    HTTP_REQUESTS_STATUS, HTTP_REQUESTS_URI, HTTP_REQUEST_BODY_NETWORK_SIZE_BYTES_COUNTER,
-    HTTP_REQUEST_BODY_REAL_SIZE_BYTES_COUNTER,
+    HTTP_REQUEST_BODY_NETWORK_SIZE_BYTES_COUNTER, HTTP_REQUEST_BODY_REAL_SIZE_BYTES_COUNTER,
+    HTTP_REQUEST_DURATION_SECONDS_HISTOGRAM, HTTP_REQUEST_MACHINE, HTTP_REQUEST_METHOD,
+    HTTP_REQUEST_STATUS, HTTP_REQUEST_URI,
 };
 use quick_xml::writer::Writer;
 use soap::Serializable;
@@ -194,14 +194,14 @@ async fn get_request_payload(
             if monitoring_conf.count_http_request_body_network_size_per_machine() =>
         {
             counter!(HTTP_REQUEST_BODY_NETWORK_SIZE_BYTES_COUNTER,
-                HTTP_REQUESTS_METHOD => request_data.method().to_string(),
-                HTTP_REQUESTS_URI => request_data.uri().to_string(),
-                HTTP_REQUESTS_MACHINE => request_data.principal().to_string())
+                HTTP_REQUEST_METHOD => request_data.method().to_string(),
+                HTTP_REQUEST_URI => request_data.uri().to_string(),
+                HTTP_REQUEST_MACHINE => request_data.principal().to_string())
         }
         _ => {
             counter!(HTTP_REQUEST_BODY_NETWORK_SIZE_BYTES_COUNTER,
-                HTTP_REQUESTS_METHOD => request_data.method().to_string(),
-                HTTP_REQUESTS_URI => request_data.uri().to_string())
+                HTTP_REQUEST_METHOD => request_data.method().to_string(),
+                HTTP_REQUEST_URI => request_data.uri().to_string())
         }
     };
     http_request_body_network_size_bytes_counter.increment(data.len().try_into()?);
@@ -220,14 +220,14 @@ async fn get_request_payload(
                     if monitoring_conf.count_http_request_body_real_size_per_machine() =>
                 {
                     counter!(HTTP_REQUEST_BODY_REAL_SIZE_BYTES_COUNTER,
-                        HTTP_REQUESTS_METHOD => request_data.method().to_string(),
-                        HTTP_REQUESTS_URI => request_data.uri().to_string(),
-                        HTTP_REQUESTS_MACHINE => request_data.principal().to_string())
+                        HTTP_REQUEST_METHOD => request_data.method().to_string(),
+                        HTTP_REQUEST_URI => request_data.uri().to_string(),
+                        HTTP_REQUEST_MACHINE => request_data.principal().to_string())
                 }
                 _ => {
                     counter!(HTTP_REQUEST_BODY_REAL_SIZE_BYTES_COUNTER,
-                        HTTP_REQUESTS_METHOD => request_data.method().to_string(),
-                        HTTP_REQUESTS_URI => request_data.uri().to_string())
+                        HTTP_REQUEST_METHOD => request_data.method().to_string(),
+                        HTTP_REQUEST_URI => request_data.uri().to_string())
                 }
             };
             http_request_body_real_size_bytes_counter.increment(bytes.len().try_into()?);
@@ -438,10 +438,10 @@ fn log_response(
 ) {
     let duration = start.elapsed().as_secs_f64();
 
-    histogram!(HTTP_REQUESTS_DURATION_SECONDS_HISTOGRAM,
-        HTTP_REQUESTS_METHOD => method.to_owned(),
-        HTTP_REQUESTS_STATUS => status.to_string(),
-        HTTP_REQUESTS_URI => uri.to_owned())
+    histogram!(HTTP_REQUEST_DURATION_SECONDS_HISTOGRAM,
+        HTTP_REQUEST_METHOD => method.to_owned(),
+        HTTP_REQUEST_STATUS => status.to_string(),
+        HTTP_REQUEST_URI => uri.to_owned())
     .record(duration);
 
     // MDC is thread related, so it should be safe to use it in a non-async

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -385,13 +385,13 @@ fn log_response(
     principal: &str,
     conn_status: ConnectionStatus,
 ) {
-    let duration = start.elapsed();
+    let duration = start.elapsed().as_secs_f64();
 
     histogram!(HTTP_REQUESTS_DURATION_SECONDS_HISTOGRAM,
         HTTP_REQUESTS_METHOD => method.to_owned(),
         HTTP_REQUESTS_STATUS => status.to_string(),
         HTTP_REQUESTS_URI => uri.to_owned())
-    .record(duration.as_secs_f64());
+    .record(duration);
 
     // MDC is thread related, so it should be safe to use it in a non-async
     // function.
@@ -400,7 +400,7 @@ fn log_response(
     log_mdc::insert("http_uri", uri);
     log_mdc::insert(
         "response_time",
-        format!("{:.3}", duration.as_micros() / 1000),
+        format!("{:.3}", duration * 1000.0),
     );
     log_mdc::insert("ip", addr.ip().to_string());
     log_mdc::insert("port", addr.port().to_string());

--- a/server/src/monitoring.rs
+++ b/server/src/monitoring.rs
@@ -22,11 +22,11 @@ pub const EVENTS_MACHINE: &str = "machine";
 
 pub const FAILED_EVENTS_COUNTER: &str = "openwec_event_output_failures_total";
 
-pub const HTTP_REQUESTS_DURATION_SECONDS_HISTOGRAM: &str = "http_request_duration_seconds";
-pub const HTTP_REQUESTS_METHOD: &str = "method";
-pub const HTTP_REQUESTS_URI: &str = "uri";
-pub const HTTP_REQUESTS_STATUS: &str = "status";
-pub const HTTP_REQUESTS_MACHINE: &str = "machine";
+pub const HTTP_REQUEST_DURATION_SECONDS_HISTOGRAM: &str = "http_request_duration_seconds";
+pub const HTTP_REQUEST_METHOD: &str = "method";
+pub const HTTP_REQUEST_URI: &str = "uri";
+pub const HTTP_REQUEST_STATUS: &str = "status";
+pub const HTTP_REQUEST_MACHINE: &str = "machine";
 
 pub const HTTP_REQUEST_BODY_NETWORK_SIZE_BYTES_COUNTER: &str =
     "http_request_body_network_size_bytes_total";
@@ -45,8 +45,8 @@ pub fn init(settings: &Monitoring) -> Result<()> {
     let builder = PrometheusBuilder::new()
         .with_http_listener(addr)
         .set_buckets_for_metric(
-            Matcher::Full(HTTP_REQUESTS_DURATION_SECONDS_HISTOGRAM.to_string()),
-            settings.http_requests_histogram_buckets(),
+            Matcher::Full(HTTP_REQUEST_DURATION_SECONDS_HISTOGRAM.to_string()),
+            settings.http_request_duration_buckets(),
         )?;
 
     info!("Starting monitoring server on {}", addr);
@@ -69,7 +69,7 @@ pub fn init(settings: &Monitoring) -> Result<()> {
         "Number of events that could not be written to outputs by openwec"
     );
     describe_histogram!(
-        HTTP_REQUESTS_DURATION_SECONDS_HISTOGRAM,
+        HTTP_REQUEST_DURATION_SECONDS_HISTOGRAM,
         Unit::Seconds,
         "HTTP requests duration histogram"
     );

--- a/server/src/monitoring.rs
+++ b/server/src/monitoring.rs
@@ -9,31 +9,42 @@ use log::info;
 use metrics::{describe_counter, describe_histogram, Unit};
 use metrics_exporter_prometheus::{Matcher, PrometheusBuilder};
 
-pub const MESSAGES_COUNTER: &str = "openwec_messages_total";
+// input metrics
+
+pub const INPUT_MESSAGES_COUNTER: &str = "openwec_input_messages_total";
 pub const MESSAGES_ACTION: &str = "action";
 pub const MESSAGES_ACTION_HEARTBEAT: &str = "heartbeat";
 pub const MESSAGES_ACTION_EVENTS: &str = "events";
 pub const MESSAGES_ACTION_ENUMERATE: &str = "enumerate";
 
-pub const EVENTS_COUNTER: &str = "openwec_received_events_total";
-pub const EVENTS_SUBSCRIPTION_UUID: &str = "subscription_uuid";
-pub const EVENTS_SUBSCRIPTION_NAME: &str = "subscription_name";
-pub const EVENTS_MACHINE: &str = "machine";
+pub const INPUT_EVENTS_COUNTER: &str = "openwec_input_events_total";
+pub const SUBSCRIPTION_UUID: &str = "subscription_uuid";
+pub const SUBSCRIPTION_NAME: &str = "subscription_name";
+pub const MACHINE: &str = "machine";
 
-pub const FAILED_EVENTS_COUNTER: &str = "openwec_event_output_failures_total";
+pub const INPUT_EVENT_BYTES_COUNTER: &str = "openwec_input_event_bytes_total";
+pub const INPUT_EVENT_PARSING_FAILURES: &str = "openwec_input_event_parsing_failures_total";
+pub const INPUT_EVENT_PARSING_FAILURE_ERROR_TYPE: &str = "type";
 
-pub const HTTP_REQUEST_DURATION_SECONDS_HISTOGRAM: &str = "http_request_duration_seconds";
-pub const HTTP_REQUEST_METHOD: &str = "method";
+// http metrics
+
+pub const HTTP_REQUESTS_COUNTER: &str = "openwec_http_requests_total";
+
+pub const HTTP_REQUEST_DURATION_SECONDS_HISTOGRAM: &str = "openwec_http_request_duration_seconds";
 pub const HTTP_REQUEST_URI: &str = "uri";
-pub const HTTP_REQUEST_STATUS: &str = "status";
-pub const HTTP_REQUEST_MACHINE: &str = "machine";
+pub const HTTP_REQUEST_STATUS_CODE: &str = "code";
 
 pub const HTTP_REQUEST_BODY_NETWORK_SIZE_BYTES_COUNTER: &str =
-    "http_request_body_network_size_bytes_total";
+    "openwec_http_request_body_network_size_bytes_total";
 pub const HTTP_REQUEST_BODY_REAL_SIZE_BYTES_COUNTER: &str =
-    "http_request_body_real_size_bytes_total";
+    "openwec_http_request_body_real_size_bytes_total";
 
-pub const EVENT_SIZE_BYTES_COUNTER: &str = "openwec_event_size_bytes_total";
+// output metrics
+
+pub const OUTPUT_DRIVER_FAILURES: &str = "openwec_output_driver_failures_total";
+pub const OUTPUT_DRIVER: &str = "driver";
+pub const OUTPUT_FORMAT_FAILURES: &str = "openwec_output_format_failures_total";
+pub const OUTPUT_FORMAT: &str = "format";
 
 pub fn init(settings: &Monitoring) -> Result<()> {
     let addr = SocketAddr::from((
@@ -53,25 +64,38 @@ pub fn init(settings: &Monitoring) -> Result<()> {
 
     builder.install()?;
 
+    // input
     describe_counter!(
-        MESSAGES_COUNTER,
+        INPUT_EVENTS_COUNTER,
         Unit::Count,
-        "Number of messages received by openwec"
+        "The total number of events received by openwec"
     );
     describe_counter!(
-        EVENTS_COUNTER,
-        Unit::Count,
-        "Number of events received by openwec"
+        INPUT_EVENT_BYTES_COUNTER,
+        Unit::Bytes,
+        "The total size of all events received by openwec"
     );
     describe_counter!(
-        FAILED_EVENTS_COUNTER,
+        INPUT_MESSAGES_COUNTER,
         Unit::Count,
-        "Number of events that could not be written to outputs by openwec"
+        "The total number of messages received by openwec"
+    );
+    describe_counter!(
+        INPUT_EVENT_PARSING_FAILURES,
+        Unit::Count,
+        "The total number of event parsing failures"
+    );
+
+    // http
+    describe_counter!(
+        HTTP_REQUESTS_COUNTER,
+        Unit::Count,
+        "The total number of HTTP requests handled by openwec"
     );
     describe_histogram!(
         HTTP_REQUEST_DURATION_SECONDS_HISTOGRAM,
         Unit::Seconds,
-        "HTTP requests duration histogram"
+        "Histogram of response duration for HTTP requests"
     );
     describe_counter!(
         HTTP_REQUEST_BODY_NETWORK_SIZE_BYTES_COUNTER,
@@ -83,10 +107,17 @@ pub fn init(settings: &Monitoring) -> Result<()> {
         Unit::Bytes,
         "The total size of all http requests body received by openwec after decryption and decompression"
     );
+
+    // output
     describe_counter!(
-        EVENT_SIZE_BYTES_COUNTER,
-        Unit::Bytes,
-        "The total size of all events received by openwec"
+        OUTPUT_DRIVER_FAILURES,
+        Unit::Count,
+        "The total number of output driver failures"
+    );
+    describe_counter!(
+        OUTPUT_FORMAT_FAILURES,
+        Unit::Count,
+        "The total number of output format failures"
     );
 
     Ok(())

--- a/server/src/monitoring.rs
+++ b/server/src/monitoring.rs
@@ -9,17 +9,18 @@ use log::info;
 use metrics::{describe_counter, describe_histogram, Unit};
 use metrics_exporter_prometheus::{Matcher, PrometheusBuilder};
 
-pub const MESSAGES_COUNTER: &str = "openwec_message_total";
+pub const MESSAGES_COUNTER: &str = "openwec_messages_total";
 pub const MESSAGES_ACTION: &str = "action";
 pub const MESSAGES_ACTION_HEARTBEAT: &str = "heartbeat";
 pub const MESSAGES_ACTION_EVENTS: &str = "events";
 pub const MESSAGES_ACTION_ENUMERATE: &str = "enumerate";
 
-pub const EVENTS_COUNTER: &str = "openwec_event_received_total";
+pub const EVENTS_COUNTER: &str = "openwec_received_events_total";
 pub const EVENTS_SUBSCRIPTION_UUID: &str = "subscription_uuid";
 pub const EVENTS_SUBSCRIPTION_NAME: &str = "subscription_name";
+pub const EVENTS_MACHINE: &str = "machine";
 
-pub const FAILED_EVENTS_COUNTER: &str = "openwec_event_output_failure_total";
+pub const FAILED_EVENTS_COUNTER: &str = "openwec_event_output_failures_total";
 
 pub const HTTP_REQUESTS_DURATION_SECONDS_HISTOGRAM: &str = "http_request_duration_seconds";
 pub const HTTP_REQUESTS_METHOD: &str = "method";

--- a/server/src/monitoring.rs
+++ b/server/src/monitoring.rs
@@ -26,6 +26,14 @@ pub const HTTP_REQUESTS_DURATION_SECONDS_HISTOGRAM: &str = "http_request_duratio
 pub const HTTP_REQUESTS_METHOD: &str = "method";
 pub const HTTP_REQUESTS_URI: &str = "uri";
 pub const HTTP_REQUESTS_STATUS: &str = "status";
+pub const HTTP_REQUESTS_MACHINE: &str = "machine";
+
+pub const HTTP_REQUEST_BODY_NETWORK_SIZE_BYTES_COUNTER: &str =
+    "http_request_body_network_size_bytes_total";
+pub const HTTP_REQUEST_BODY_REAL_SIZE_BYTES_COUNTER: &str =
+    "http_request_body_real_size_bytes_total";
+
+pub const EVENT_SIZE_BYTES_COUNTER: &str = "openwec_event_size_bytes_total";
 
 pub fn init(settings: &Monitoring) -> Result<()> {
     let addr = SocketAddr::from((
@@ -64,6 +72,21 @@ pub fn init(settings: &Monitoring) -> Result<()> {
         HTTP_REQUESTS_DURATION_SECONDS_HISTOGRAM,
         Unit::Seconds,
         "HTTP requests duration histogram"
+    );
+    describe_counter!(
+        HTTP_REQUEST_BODY_NETWORK_SIZE_BYTES_COUNTER,
+        Unit::Bytes,
+        "The total size of all http requests body received by openwec"
+    );
+    describe_counter!(
+        HTTP_REQUEST_BODY_REAL_SIZE_BYTES_COUNTER,
+        Unit::Bytes,
+        "The total size of all http requests body received by openwec after decryption and decompression"
+    );
+    describe_counter!(
+        EVENT_SIZE_BYTES_COUNTER,
+        Unit::Bytes,
+        "The total size of all events received by openwec"
     );
 
     Ok(())

--- a/server/src/monitoring.rs
+++ b/server/src/monitoring.rs
@@ -1,0 +1,69 @@
+use std::{
+    net::{IpAddr, SocketAddr},
+    str::FromStr,
+};
+
+use anyhow::Result;
+use common::settings::Monitoring;
+use log::info;
+use metrics::{describe_counter, describe_histogram, Unit};
+use metrics_exporter_prometheus::{Matcher, PrometheusBuilder};
+
+pub const MESSAGES_COUNTER: &str = "openwec_message_total";
+pub const MESSAGES_ACTION: &str = "action";
+pub const MESSAGES_ACTION_HEARTBEAT: &str = "heartbeat";
+pub const MESSAGES_ACTION_EVENTS: &str = "events";
+pub const MESSAGES_ACTION_ENUMERATE: &str = "enumerate";
+
+pub const EVENTS_COUNTER: &str = "openwec_event_received_total";
+pub const EVENTS_SUBSCRIPTION_UUID: &str = "subscription_uuid";
+pub const EVENTS_SUBSCRIPTION_NAME: &str = "subscription_name";
+
+pub const FAILED_EVENTS_COUNTER: &str = "openwec_event_output_failure_total";
+
+pub const HTTP_REQUESTS_DURATION_SECONDS_HISTOGRAM: &str = "http_request_duration_seconds";
+pub const HTTP_REQUESTS_METHOD: &str = "method";
+pub const HTTP_REQUESTS_URI: &str = "uri";
+pub const HTTP_REQUESTS_STATUS: &str = "status";
+
+pub fn init(settings: &Monitoring) -> Result<()> {
+    let addr = SocketAddr::from((
+        IpAddr::from_str(settings.listen_address())
+            .expect("Failed to parse monitoring.listen_address"),
+        settings.listen_port(),
+    ));
+
+    let builder = PrometheusBuilder::new()
+        .with_http_listener(addr)
+        .set_buckets_for_metric(
+            Matcher::Full(HTTP_REQUESTS_DURATION_SECONDS_HISTOGRAM.to_string()),
+            settings.http_requests_histogram_buckets(),
+        )?;
+
+    info!("Starting monitoring server on {}", addr);
+
+    builder.install()?;
+
+    describe_counter!(
+        MESSAGES_COUNTER,
+        Unit::Count,
+        "Number of messages received by openwec"
+    );
+    describe_counter!(
+        EVENTS_COUNTER,
+        Unit::Count,
+        "Number of events received by openwec"
+    );
+    describe_counter!(
+        FAILED_EVENTS_COUNTER,
+        Unit::Count,
+        "Number of events that could not be written to outputs by openwec"
+    );
+    describe_histogram!(
+        HTTP_REQUESTS_DURATION_SECONDS_HISTOGRAM,
+        Unit::Seconds,
+        "HTTP requests duration histogram"
+    );
+
+    Ok(())
+}

--- a/server/src/output.rs
+++ b/server/src/output.rs
@@ -138,6 +138,10 @@ impl Output {
         )
     }
 
+    pub fn driver(&self) -> String {
+        format!("{:?}", self.subscription_output_driver)
+    }
+
     pub async fn write(
         &self,
         metadata: Arc<EventMetadata>,


### PR DESCRIPTION
Implements #189 

This adds the following metrics exposed by a Prometheus endpoint: https://github.com/vruello/openwec/blob/metrics-rs/doc/monitoring.md#available-metrics

Machine labels can be added for any supported metric in the monitoring settings:
```toml
# [monitoring]

# [Required]
# Listen address of the Prometheus-compatible endpoint
# listen_address =

# [Required]
# Listen port of the Prometheus-compatible endpoint
# listen_port =

# [Optional]
# The refresh interval of "openwec_machines" gauge
# machines_refresh_interval = 30

# [Optional]
# Request duration buckets (in seconds) used by the "openwec_http_request_duration_seconds" histogram
# http_request_duration_buckets = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]

# [Optional]
# If set, a "machine" label will be added to the "openwec_input_events_total" metric
# Warning: this may cause a HUGE increase in metric cardinality
# count_input_events_per_machine = false

# [Optional]
# If set, a "machine" label will be added to the "openwec_input_event_bytes_total" metric
# Warning: this may cause a HUGE increase in metric cardinality
# count_input_event_bytes_per_machine = false

# [Optional]
# If set, a "machine" label will be added to the "openwec_http_request_body_network_size_bytes_total" metric
# Warning: this may cause a HUGE increase in metric cardinality
# count_http_request_body_network_size_per_machine = false

# [Optional]
# If set, a "machine" label will be added to the "openwec_http_request_body_real_size_bytes_total" metric
# Warning: this may cause a HUGE increase in metric cardinality
# count_http_request_body_real_size_per_machine = false
```