### PR TITLE
AArch64 container image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,6 +3,7 @@ name: Create and publish a Docker image
 # Configures this workflow to run every time a change is pushed to the branch called `main` or a tag named 'v*' is pushed.
 
 on:
+  workflow_dispatch:
   push:
     branches: ['main']
     tags:
@@ -16,29 +17,37 @@ env:
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
   image:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        base-image: [debian, alpine]
+        platform: [linux/amd64, linux/arm64]
+
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest'  }}
+
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
       contents: read
       packages: write
 
-    strategy:
-      fail-fast: false
-      matrix:
-        base-image: [debian, alpine]
     steps:
       - name: Prepare
         run: |
           if [ "${{ matrix.base-image }}" = "debian" ]; then
             echo "DOCKERFILE=openwec.Dockerfile" >> $GITHUB_ENV
-            echo "FLAVOR_OPTS=" >> $GITHUB_ENV
           elif [ "${{ matrix.base-image }}" = "alpine" ]; then
             echo "DOCKERFILE=openwec-alpine.Dockerfile" >> $GITHUB_ENV
-            echo "FLAVOR_OPTS=suffix=-alpine,onlatest=true" >> $GITHUB_ENV
           fi
+
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349
+
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
@@ -53,20 +62,86 @@ jobs:
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        id: build
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          platforms: ${{ matrix.platform }}
+          context: .
+          file: docker/${{ env.DOCKERFILE }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.base-image }}-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  create-multi-arch-manifest:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        base-image: [debian, alpine]
+
+    needs:
+      - image
+    steps:
+      - name: Prepare
+        run: |
+          if [ "${{ matrix.base-image }}" = "debian" ]; then
+            echo "FLAVOR_OPTS=" >> $GITHUB_ENV
+          elif [ "${{ matrix.base-image }}" = "alpine" ]; then
+            echo "FLAVOR_OPTS=suffix=-alpine,onlatest=true" >> $GITHUB_ENV
+          fi
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-${{ matrix.base-image }}-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
           flavor: |
             ${{ env.FLAVOR_OPTS }}
 
-      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
-      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
-      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
-      - name: Build and push Docker image
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
-        with:
-          context: .
-          file: docker/${{ env.DOCKERFILE }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      - name: Create multi-arch manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)


### PR DESCRIPTION
This PR introduces aarch64 images. I'm leaving it in draft status until the arm64 GitHub Actions runners are publicly available.

https://github.blog/news-insights/product-news/arm64-on-github-actions-powering-faster-more-efficient-build-systems/
> We expect to begin offering Arm runners for open source projects by the end of the year. 

----

The images won’t double in number again because multi-arch manifests are used, so it looks like this on the user side:

![image](https://github.com/user-attachments/assets/4c364703-e898-4de2-85e8-83ffc6f3d03e)

----

4 image builders, merged into 2 images (alpine, debian) using multi-arch manifests:
![image](https://github.com/user-attachments/assets/799d7a53-28a5-440d-98c9-d0dc22d64c67)


The motivation is dual again:

- ARM platforms are getting more widespread, especially in cloud environments (for example, AWS Graviton), offering a more cost-effective alternative to x86-64.
- the image would help create local test and dev environments (for example, Kubernetes deployments) on Apple silicon laptops.

Special thanks to @pepov