### PR TITLE
cli: allow loading subscriptions from an empty directory

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -254,6 +254,7 @@ async fn main() {
                     .arg(arg!(<path> "Directory of configuration files or a single configuration file"))
                     .arg(arg!(-k --keep "Do not delete subscriptions that are not present in the configuration"))
                     .arg(arg!(-y --yes "Do not prompt for confirmation when <path> is a configuration file and --keep is not used"))
+                    .arg(arg!(-e --"allow-empty" "Allow loading from empty directories"))
                     .arg(arg!(-r --revision <REVISION> "Revision name of the configuration. If present, it will be added by openwec as metadata of all events received using this subscription."))
                 )
                 .subcommand(

--- a/cli/src/subscriptions.rs
+++ b/cli/src/subscriptions.rs
@@ -970,6 +970,7 @@ async fn load(db: &Db, matches: &ArgMatches) -> Result<()> {
         .ok_or_else(|| anyhow!("Missing argument path"))?;
     let keep = matches.get_one::<bool>("keep").expect("Defaulted by clap");
     let yes = matches.get_one::<bool>("yes").expect("Defaulted by clap");
+    let allow_empty = matches.get_one::<bool>("allow-empty").expect("Defaulted by clap");
     let revision = matches.get_one::<String>("revision");
 
     let path_obj = Path::new(path);
@@ -985,7 +986,7 @@ async fn load(db: &Db, matches: &ArgMatches) -> Result<()> {
     let subscriptions =
         config::load_from_path(path, revision).context("Failed to load config files")?;
 
-    if subscriptions.is_empty() {
+    if subscriptions.is_empty() && !allow_empty {
         bail!("Could not find any subscriptions");
     }
 


### PR DESCRIPTION
It's not April Fools' Day yet, but joking aside, we found this option useful in cases where subscriptions are generated as part of an automated system where having zero subscriptions is allowed (OpenWEC running in a Kubernetes pod, never stopped even if there is no useful work to do).

(OpenWEC has already been able to start with zero subscription, but the CLI did not allow such state transition.)