### PR TITLE
Make collector hostname optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2449,6 +2449,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
+ "url",
  "uuid",
  "x509-parser",
  "xmlparser",

--- a/common/src/settings.rs
+++ b/common/src/settings.rs
@@ -45,7 +45,7 @@ impl Tls {
 #[derive(Debug, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct Collector {
-    hostname: String,
+    hostname: Option<String>,
     listen_address: String,
     listen_port: Option<u16>,
     max_content_length: Option<u64>,
@@ -55,8 +55,8 @@ pub struct Collector {
 }
 
 impl Collector {
-    pub fn hostname(&self) -> &str {
-        &self.hostname
+    pub fn hostname(&self) -> Option<&str> {
+        self.hostname.as_deref()
     }
 
     pub fn listen_address(&self) -> &str {
@@ -416,7 +416,7 @@ impl Monitoring {
         self.count_http_request_body_real_size_per_machine
             .unwrap_or(false)
     }
-    
+
     pub fn machines_refresh_interval(&self) -> u64 {
         self.machines_refresh_interval.unwrap_or(30)
     }
@@ -517,7 +517,7 @@ mod tests {
         let s = Settings::from_str(CONFIG_KERBEROS_SQLITE).unwrap();
         assert_eq!(s.collectors().len(), 1);
         let collector = &s.collectors()[0];
-        assert_eq!(collector.hostname(), "wec.windomain.local");
+        assert_eq!(collector.hostname().unwrap(), "wec.windomain.local");
         assert_eq!(collector.listen_address(), "0.0.0.0");
         assert_eq!(collector.listen_port(), 5986);
         assert_eq!(collector.max_content_length(), 1000);
@@ -587,7 +587,7 @@ mod tests {
         let s = Settings::from_str(CONFIG_TLS_POSTGRES).unwrap();
         assert_eq!(s.collectors().len(), 1);
         let collector = &s.collectors()[0];
-        assert_eq!(collector.hostname(), "wec.windomain.local");
+        assert_eq!(collector.hostname().unwrap(), "wec.windomain.local");
         assert_eq!(collector.listen_address(), "0.0.0.0");
         // Checks default values
         assert_eq!(collector.listen_port(), 5985);
@@ -804,7 +804,7 @@ mod tests {
 
         [collectors.authentication]
         type = "Kerberos"
-        service_principal_name = "http/wec.windomain.local@WINDOMAIN.LOCAL"   
+        service_principal_name = "http/wec.windomain.local@WINDOMAIN.LOCAL"
     "#;
 
     #[test]
@@ -812,7 +812,7 @@ mod tests {
         let s = Settings::from_str(GETTING_STARTED).unwrap();
         assert_eq!(s.collectors().len(), 1);
         let collector = &s.collectors()[0];
-        assert_eq!(collector.hostname(), "wec.windomain.local");
+        assert_eq!(collector.hostname().unwrap(), "wec.windomain.local");
         assert_eq!(collector.listen_address(), "0.0.0.0");
 
         let kerberos = match collector.authentication() {

--- a/openwec.conf.sample.toml
+++ b/openwec.conf.sample.toml
@@ -72,7 +72,7 @@
 # [Optional]
 # Set server logging verbosity
 # This parameter is overwritten by --verbosity argument.
-# Default value is warn 
+# Default value is warn
 # Possible values are: error, warn, info, debug, trace
 # verbosity = "warn"
 
@@ -86,7 +86,7 @@
 
 # [Optional]
 # Server log formatting pattern
-# Pattern syntax is explained here: https://docs.rs/log4rs/latest/log4rs/encode/pattern 
+# Pattern syntax is explained here: https://docs.rs/log4rs/latest/log4rs/encode/pattern
 # Default value is None, meaning "{d} {l} {t} - {m}{n}"
 # server_logs_pattern = None
 
@@ -101,7 +101,7 @@
 
 # [Optional]
 # Access log formatting pattern
-# Pattern syntax is explained here: https://docs.rs/log4rs/latest/log4rs/encode/pattern 
+# Pattern syntax is explained here: https://docs.rs/log4rs/latest/log4rs/encode/pattern
 # Contextual information can be accessed using {X(<value>)}. Available values are:
 # - http_status
 # - http_method
@@ -143,7 +143,7 @@
 
 # [Required]
 # Postgres database port
-# port = 5432 
+# port = 5432
 
 # [Required]
 # Postgres database name. It must already exist and user <postgres.user> should

--- a/openwec.conf.sample.toml
+++ b/openwec.conf.sample.toml
@@ -191,9 +191,10 @@
 
 # This defines one collector
 [[collectors]]
-# [Required]
+# [Optional]
 # Local Hostname
 # Clients will contact this hostname to send their events
+# If unset, clients will send events to the same hostname that is configured in their "Subscription Manager"
 # hostname = "openwec.mydomain.local"
 
 # [Required]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -54,3 +54,4 @@ strum = { version = "0.26.1", features = ["derive"] }
 leon = "3.0.1"
 metrics = "0.24.0"
 metrics-exporter-prometheus = { version = "0.16.0", features = ["http-listener"] }
+url = "2.5.4"

--- a/server/src/logic.rs
+++ b/server/src/logic.rs
@@ -59,7 +59,8 @@ fn create_subscription_body(
     subscription: &Arc<Subscription>,
     bookmark: Option<String>,
     collector: &Collector,
-    auth_ctx: &AuthenticationContext
+    collector_hostname: &str,
+    auth_ctx: &AuthenticationContext,
 ) -> SubscriptionBody {
     let public_version = subscription.public_version_string();
     let identifier = subscription.uuid_string();
@@ -75,13 +76,13 @@ fn create_subscription_body(
         address: match auth_ctx {
             AuthenticationContext::Kerberos(_) => format!(
                 "http://{}:{}/wsman/subscriptions/{}",
-                collector.hostname(),
+                collector_hostname,
                 collector.advertized_port(),
                 identifier
             ),
             AuthenticationContext::Tls(_, _) => format!(
                 "https://{}:{}/wsman/subscriptions/{}",
-                collector.hostname(),
+                collector_hostname,
                 collector.advertized_port(),
                 identifier
             ),
@@ -106,6 +107,7 @@ async fn handle_enumerate(
     subscriptions: Subscriptions,
     request_data: &RequestData,
     auth_ctx: &AuthenticationContext,
+    message: &Message,
 ) -> Result<Response> {
     // Check that URI corresponds to an enumerate Request
     let uri = match request_data.category() {
@@ -123,6 +125,25 @@ async fn handle_enumerate(
         request_data.principal(),
         uri
     );
+
+    let collector_hostname = if let Some(hostname) = collector.hostname() {
+        hostname.to_owned()
+    } else {
+        let hostname_from_message = message.header().to().and_then(|to| {
+            let url = url::Url::parse(to).ok()?;
+            url.host_str().map(|s| s.to_owned())
+        });
+
+        let Some(hostname) = hostname_from_message else {
+            warn!(
+                "Collector hostname cannot be extracted from To header ({:?}), rejecting Enumerate request",
+                message.header().to()
+            );
+            return Ok(Response::err(StatusCode::BAD_REQUEST));
+        };
+
+        hostname
+    };
 
     // Clone subscriptions references into a new vec
     let current_subscriptions = {
@@ -232,7 +253,7 @@ async fn handle_enumerate(
             bookmark
         );
 
-        let body = create_subscription_body(&subscription, bookmark, collector, auth_ctx);
+        let body = create_subscription_body(&subscription, bookmark, collector, &collector_hostname, auth_ctx,);
 
         res_subscriptions.push(SoapSubscription {
             version: subscription.public_version_string(),
@@ -630,7 +651,7 @@ pub async fn handle_message(
     debug!("Received {} request", action);
 
     if action == ACTION_ENUMERATE {
-        handle_enumerate(collector, &db, subscriptions, request_data, auth_ctx)
+        handle_enumerate(collector, &db, subscriptions, request_data, auth_ctx, message)
             .await
             .context("Failed to handle Enumerate action")
     } else if action == ACTION_END || action == ACTION_SUBSCRIPTION_END {

--- a/server/src/soap.rs
+++ b/server/src/soap.rs
@@ -409,6 +409,10 @@ impl Header {
         }
     }
 
+    pub fn to(&self) -> Option<&String> {
+        self.to.as_ref()
+    }
+
     /// Get a reference to the header's bookmarks.
     pub fn bookmarks(&self) -> Option<&String> {
         self.bookmarks.as_ref()


### PR DESCRIPTION
This reduces configuration complexity, especially in cases when load balancing is used and one wants all traffic to go through the load balancer.

If the collector hostname field is unset in the configuration, clients will send events to the same hostname that is configured in their "Subscription Manager".

(Since Enumerate requests are both encrypted and authenticated, using the hostname sent by the client is harmless and practical in my opinion,)