### PR TITLE
Fix sasl lib for building alpine docker image

### DIFF
--- a/docker/openwec-alpine.Dockerfile
+++ b/docker/openwec-alpine.Dockerfile
@@ -16,7 +16,7 @@ RUN apk upgrade --no-cache && apk add --no-cache \
     openssl-dev \
     krb5-dev  \
     pkgconf \
-    libsasl \
+    cyrus-sasl-dev \
     rust-bindgen
 
 COPY --from=planner /SRC/recipe.json recipe.json


### PR DESCRIPTION
Build is fixed: https://github.com/vruello/openwec/actions/runs/15908731370