### PR TITLE
Round-robin multiple Kafka topics

### DIFF
--- a/common/src/subscription.rs
+++ b/common/src/subscription.rs
@@ -50,7 +50,8 @@ impl KafkaConfiguration {
 
     /// Get the kafka configuration's topic split on commas.
     pub fn topic_as_array(&self) -> Vec<String> {
-        self.topic.split(',')
+        self.topic
+            .split(',')
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty())
             .collect()

--- a/common/src/subscription.rs
+++ b/common/src/subscription.rs
@@ -47,6 +47,14 @@ impl KafkaConfiguration {
     pub fn options(&self) -> &HashMap<String, String> {
         &self.options
     }
+
+    /// Get the kafka configuration's topic split on commas.
+    pub fn topic_as_array(&self) -> Vec<String> {
+        self.topic.split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect()
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]

--- a/common/src/subscription.rs
+++ b/common/src/subscription.rs
@@ -47,15 +47,6 @@ impl KafkaConfiguration {
     pub fn options(&self) -> &HashMap<String, String> {
         &self.options
     }
-
-    /// Get the kafka configuration's topic split on commas.
-    pub fn topic_as_array(&self) -> Vec<String> {
-        self.topic
-            .split(',')
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty())
-            .collect()
-    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]

--- a/doc/outputs.md
+++ b/doc/outputs.md
@@ -73,7 +73,9 @@ $ openwec subscriptions edit <subscription> outputs add --format <format> files 
 
 The Kafka driver sends events in a Kafka topic.
 
-For a given subscription, all events will be sent in the configured Kafka topic. If there are multiple topics then topic can contain that list, delimited with commas. You may want to add additionnal options to the inner Kafka client, such as `bootstrap.servers`. This options will be directly given to `librdkafka` (available options are listed here: https://docs.confluent.io/platform/current/clients/librdkafka/html/md_CONFIGURATION.html).
+For a given subscription, all events will be sent in the configured Kafka topic. If multiple topics are provided, delimited by commas, then the events are evenly distributed across the listed topics.
+
+You may want to add additionnal options to the inner Kafka client, such as `bootstrap.servers`. This options will be directly given to `librdkafka` (available options are listed here: https://docs.confluent.io/platform/current/clients/librdkafka/html/md_CONFIGURATION.html).
 
 > [!TIP]
 > If multiple outputs use the Kafka driver and connect to the same Kafka cluster, it is recommended to configure the additional options in OpenWEC settings (`outputs.kafka.options`) **and** to omit the `options` parameter in Kafka output configuration. This way, only one Kafka client will be used by all the outputs, which is more resource efficient.

--- a/doc/outputs.md
+++ b/doc/outputs.md
@@ -73,7 +73,7 @@ $ openwec subscriptions edit <subscription> outputs add --format <format> files 
 
 The Kafka driver sends events in a Kafka topic.
 
-For a given subscription, all events will be sent in the configured Kafka topic. You may want to add additionnal options to the inner Kafka client, such as `bootstrap.servers`. This options will be directly given to `librdkafka` (available options are listed here: https://docs.confluent.io/platform/current/clients/librdkafka/html/md_CONFIGURATION.html).
+For a given subscription, all events will be sent in the configured Kafka topic. If there are multiple topics then topic can contain that list, delimited with commas. You may want to add additionnal options to the inner Kafka client, such as `bootstrap.servers`. This options will be directly given to `librdkafka` (available options are listed here: https://docs.confluent.io/platform/current/clients/librdkafka/html/md_CONFIGURATION.html).
 
 > [!TIP]
 > If multiple outputs use the Kafka driver and connect to the same Kafka cluster, it is recommended to configure the additional options in OpenWEC settings (`outputs.kafka.options`) **and** to omit the `options` parameter in Kafka output configuration. This way, only one Kafka client will be used by all the outputs, which is more resource efficient.

--- a/server/src/drivers/kafka.rs
+++ b/server/src/drivers/kafka.rs
@@ -8,7 +8,13 @@ use rdkafka::{
     util::Timeout,
     ClientConfig,
 };
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{Arc, atomic::{
+        AtomicUsize,
+        Ordering,
+    }},
+    time::Duration,
+};
 
 use crate::{event::EventMetadata, output::OutputDriver};
 
@@ -43,6 +49,7 @@ impl OutputKafkaContext {
 pub struct OutputKafka {
     config: KafkaConfiguration,
     producer: FutureProducer,
+    topic_index: AtomicUsize,
 }
 
 impl OutputKafka {
@@ -75,6 +82,7 @@ impl OutputKafka {
         Ok(OutputKafka {
             config: config.clone(),
             producer,
+            topic_index: AtomicUsize::new(0),
         })
     }
 }
@@ -86,14 +94,20 @@ impl OutputDriver for OutputKafka {
         _metadata: Arc<EventMetadata>,
         events: Arc<Vec<Arc<String>>>,
     ) -> Result<()> {
+        let topics_array = self.config.topic_as_array();
+        let mut l_topic_index = self.topic_index.load(Ordering::Relaxed);
         let mut futures = Vec::new();
         for event in events.iter() {
+            // Get current topic
+            let topic = topics_array[l_topic_index].as_ref();
             // We need to explicitly assign the Key type as ()
             futures.push(self.producer.send::<(), _, _>(
-                FutureRecord::to(self.config.topic()).payload(event.as_ref()),
+                FutureRecord::to(topic).payload(event.as_ref()),
                 Timeout::After(Duration::from_secs(30)),
             ));
+            l_topic_index = (l_topic_index + 1) % topics_array.len();
         }
+        self.topic_index.store(l_topic_index, Ordering::Relaxed);
 
         // Wait for all events to be sent and ack
         let results = join_all(futures).await;


### PR DESCRIPTION
Allows the topic parameter to contain multiple topics delimited by comma (,).

This is to satisfy request #281 .

Initial testing shows fairly consistent distribution of logs across topics.
<img width="1600" height="268" alt="image" src="https://github.com/user-attachments/assets/7a595cbe-e1f3-46ab-bf9d-2e7b6a34d7ff" />
