### PR TITLE
fix(build): add --locked flag to cargo-check install

### DIFF
--- a/docker/openwec-alpine.Dockerfile
+++ b/docker/openwec-alpine.Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.21 AS chef
-RUN apk add --no-cache rust cargo && cargo install cargo-chef
+RUN apk add --no-cache rust cargo && cargo install --locked cargo-chef
 WORKDIR /SRC
 
 FROM chef AS planner

--- a/docker/openwec.Dockerfile
+++ b/docker/openwec.Dockerfile
@@ -1,5 +1,5 @@
-FROM rust:slim-bookworm AS chef 
-RUN cargo install cargo-chef 
+FROM rust:slim-bookworm AS chef
+RUN cargo install --locked cargo-chef
 WORKDIR /SRC
 
 FROM chef AS planner


### PR DESCRIPTION
Hey!

I noticed that `cargo install` commands lacked the `--locked` flag, so I added them for making sure the generated builds are reproducible.

(I really like this project, many WEC related quirks are well documented, contributing / getting started was a breeze! :rocket:)