### PR TITLE
feat(server/tls): add support for multiple CAs 

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1012,6 +1012,7 @@ fn create_tls_server(
 
                 let subject =
                     subject_from_cert(cert.as_ref()).expect("Could not parse client certificate");
+                debug!("Incoming TLS connection from subject '{}'", &subject);
 
                 let issuer = issuer_from_cert(cert.as_ref())
                     .expect("Could not parse issuer from client certificate");

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -70,7 +70,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::logging::ACCESS_LOGGER;
 use crate::proxy_protocol::read_proxy_header;
-use crate::tls::{make_config, subject_from_cert};
+use crate::tls::{find_matching_ca, issuer_from_cert, make_config, subject_from_cert};
 
 pub enum RequestCategory {
     Enumerate(String),
@@ -957,7 +957,8 @@ fn create_tls_server(
             let svc_monitoring_settings = monitoring_settings.clone();
             let subscriptions = collector_subscriptions.clone();
             let collector_heartbeat_tx = collector_heartbeat_tx.clone();
-            let thumbprint = tls_config.thumbprint.clone();
+            let ca_thumbprints = tls_config.thumbprints.clone();
+
             let tls_acceptor = tls_acceptor.clone();
 
             // Create a "rx" channel end for the task
@@ -998,12 +999,13 @@ fn create_tls_server(
                     }
                 };
 
-                // get peer certificate
-                let cert = stream
+                // get peer certificates (full chain)
+                let certificate_chain = stream
                     .get_ref()
                     .1
                     .peer_certificates()
-                    .expect("Peer certificate should exist") // client auth has to happen, so this should not fail
+                    .expect("Peer certificate should exist"); // client auth has to happen, so this should not fail
+                let cert = certificate_chain
                     .first()
                     .expect("Peer certificate should not be empty") // client cert cannot be empty if authentication succeeded
                     .clone();
@@ -1011,8 +1013,22 @@ fn create_tls_server(
                 let subject =
                     subject_from_cert(cert.as_ref()).expect("Could not parse client certificate");
 
+                let issuer = issuer_from_cert(cert.as_ref())
+                    .expect("Could not parse issuer from client certificate");
+                debug!("Client certificate issued by '{}'", &issuer);
+                debug!("Known CAs: {:?}", ca_thumbprints);
+
+                // Try to find a trusted CA in the certificate chain
+                let matching_ca_entry = match find_matching_ca(certificate_chain, &ca_thumbprints) {
+                    Ok(entry) => entry,
+                    Err(e) => {
+                        warn!( "No trusted CA found in certificate chain for connection from '{}' (subject: '{}'): {:?}", real_client_addr, subject, e);
+                        return;
+                    }
+                };
+
                 // Initialize Authentication context once for each TCP connection
-                let auth_ctx = AuthenticationContext::Tls(subject, thumbprint);
+                let auth_ctx = AuthenticationContext::Tls(subject.clone(), matching_ca_entry);
 
                 // Hyper needs a wrapper for the stream
                 let io = TokioIo::new(stream);

--- a/server/src/tls.rs
+++ b/server/src/tls.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Context, Result};
 use common::encoding::encode_utf16le;
 use hex::ToHex;
-use log::{debug, info};
+use log::{debug, info, warn};
 use sha1::{Digest, Sha1};
 use std::collections::HashMap;
 use std::fs;
@@ -67,7 +67,7 @@ pub fn compute_thumbprint(cert_content: &[u8]) -> String {
 
 pub struct TlsConfig {
     pub server: Arc<ServerConfig>,
-    pub thumbprint: String,
+    pub thumbprints: HashMap<String, String>,
 }
 
 /// Create configuration for TLS connection
@@ -78,18 +78,35 @@ pub fn make_config(args: &common::settings::Tls) -> Result<TlsConfig> {
         load_priv_key(args.server_private_key()).context("Could not load private key")?;
     let ca_certs = load_certs(args.ca_certificate()).context("Could not load CA certificate")?;
 
-    let ca_cert_content: &[u8] = ca_certs
-        .first()
-        .context("CA certificate should contain at least one certificate")?
-        .as_ref();
-    let thumbprint = compute_thumbprint(ca_cert_content);
-
-    debug!("CA Thumbprint from certificate : {}", thumbprint);
+    // Ensure at least one CA is present
+    if ca_certs.is_empty() {
+        bail!("CA certificate should contain at least one certificate");
+    }
 
     let mut client_auth_roots = RootCertStore::empty();
+    let mut ca_thumbprints = HashMap::new();
 
-    // Put all certificates from given CA certificate file into certificate store
+    // Compute thumbprint for each CA and add to trust store
     for root in ca_certs {
+        let subject = subject_from_cert(root.as_ref())?;
+        let thumbprint = compute_thumbprint(root.as_ref());
+        debug!("CA Thumbprint from certificate: {}", &thumbprint);
+        if let Some(existing) = ca_thumbprints.get(&subject) {
+            if existing != &thumbprint {
+                bail!(
+                    "Duplicate CA subject with different thumbprints: {}",
+                    &subject
+                );
+            }
+            // already present, skip, but warn
+            warn!(
+                "Duplicate CA certificate found for subject: {}, thumbprint: {}",
+                &subject, &thumbprint
+            );
+            continue;
+        }
+        ca_thumbprints.insert(subject, thumbprint);
+
         client_auth_roots
             .add(root)
             .context("Could not add certificate to root of trust")?;
@@ -108,20 +125,21 @@ pub fn make_config(args: &common::settings::Tls) -> Result<TlsConfig> {
         .with_protocol_versions(ALL_VERSIONS)
         .context("Could not build configuration defaults")?
         .with_client_cert_verifier(client_cert_verifier) // add verifier
-        .with_single_cert(cert, priv_key) // add server vertification
+        .with_single_cert(cert, priv_key) // add server verification
         .context("Bad configuration certificate or key")?;
 
     // any http version is ok
     config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec(), b"http/1.0".to_vec()];
 
     info!(
-        "Loaded TLS configuration with server certificate {}",
-        args.server_certificate()
+        "Loaded TLS configuration with server certificate {} and {} CA(s)",
+        args.server_certificate(),
+        ca_thumbprints.len()
     );
 
     Ok(TlsConfig {
         server: Arc::new(config),
-        thumbprint,
+        thumbprints: ca_thumbprints,
     })
 }
 


### PR DESCRIPTION
This PR allows one to configure multiple CAs for their WEC server.

Given the following scenario:
- `Root CA`
- `CA1` and `CA2`, both signed by `Root CA` - intermediate certificate authorities
- `Client1` and `Client2` - each signed by their respective CA (`CA1`, `CA2`)

This requires the WEC server to return the proper (CA) thumbprint for each client.

I do have the following questions:
1. During my tests Windows clients only sent their peer certificate, not including the intermediate CA. Is it a known Windows behavior/quirk?
[RFC 5246 - 7.4.2](https://www.rfc-editor.org/rfc/rfc5246#section-7.4.2) says:
>  certificate_list
      This is a sequence (chain) of certificates.  The sender's
      certificate MUST come first in the list.  Each following
      certificate MUST directly certify the one preceding it.  Because
      certificate validation requires that root keys be distributed
      independently, the self-signed certificate that specifies the root
      certificate authority MAY be omitted from the chain, under the
      assumption that the remote end must already possess it in order to
      validate it in any case.

But based on [DSP0226)](https://www.dmtf.org/sites/default/files/standards/documents/DSP0226_1.0.0.pdf) - `C.3.5 http://schemas.dmtf.org/wbem/wsman/1/wsman/secprofile/https/mutual` it says the following:

> Client connects with no authorization header but supplies an X.509 certificate.

This matches with my observed behavior, but wanted to confirm nevertheless.


2. Is using the `issuer` field a proper way to identify certificate entities? I think it is enough, as the file is controlled by the user and they should be aware of its' contents. Nevertheless there is a warn for duplicates, and a hard error for same issuers, but different thumbprints.