### PR TITLE
build-pkgs: fix docker images used for release draft

### DIFF
--- a/build-pkg/Dockerfile-almalinux-9
+++ b/build-pkg/Dockerfile-almalinux-9
@@ -11,7 +11,8 @@ RUN set -eux; \
     clang \
     make \
     openssl-devel \
-    krb5-devel ; \
+    krb5-devel \
+    cyrus-sasl-devel ; \
     dnf clean all ; \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path ; \
     cargo install cargo-generate-rpm ;

--- a/build-pkg/Dockerfile-debian-bookworm
+++ b/build-pkg/Dockerfile-debian-bookworm
@@ -7,7 +7,8 @@ RUN set -eux; \
     clang \
     make \
     libssl-dev \
-    libkrb5-dev && \
-    cargo install cargo-deb
+    libkrb5-dev \
+    libsasl2-dev \
+    && cargo install cargo-deb
 
 WORKDIR /SRC

--- a/build-pkg/Dockerfile-debian-bullseye
+++ b/build-pkg/Dockerfile-debian-bullseye
@@ -7,7 +7,8 @@ RUN set -eux; \
     clang \
     make \
     libssl-dev \
-    libkrb5-dev && \
-    cargo install cargo-deb
+    libkrb5-dev \
+    libsasl2-dev \
+    && cargo install cargo-deb
 
 WORKDIR /SRC


### PR DESCRIPTION
> error: failed to run custom build command for `sasl2-sys v0.1.22+2.1.28`
>   Unable to find libsasl2 on your system. Hints: